### PR TITLE
fix doc generation script for windows

### DIFF
--- a/src/reuse/helper/jsDocGen.js
+++ b/src/reuse/helper/jsDocGen.js
@@ -7,12 +7,13 @@ const path = require("path");
 const jsdoc2md = require("jsdoc-to-markdown");
 
 const readPath = path.join(__dirname, "../");
+const readPosixPath = readPath.replace(/\\/g,"/");
 const writePath = path.join(__dirname, "../../../docs");
 
 const filesToInclude = `{index.js,modules/**/*.js}`;
 
 function generateDoc() {
-  glob(readPath + filesToInclude, async (err, files) => {
+  glob(readPosixPath + filesToInclude, async (err, files) => {
 
     if (err) {
       throw err;


### PR DESCRIPTION
`glob` is having issues with back slashes in path name on windows systems, so doc generation fails.
Replace back slashes with forward slashes. 
Should not affect anything on Unix systems.