### PR TITLE
Stack trace sometimes does not show line number of the spec where it failed

### DIFF
--- a/test/reuse/nonUi5/element/getById.spec.js
+++ b/test/reuse/nonUi5/element/getById.spec.js
@@ -33,3 +33,20 @@ describe("element - getById and catch error", function () {
       .rejects.toThrow("Function 'getById' failed");
   });
 });
+
+describe("element - getById - error case, verify error stack", function () {
+
+  it("Preparation", async function () {
+    await common.navigation.navigateToUrl("https://sapui5.hana.ondemand.com/1.99.0/");
+    await handleCookiesConsent();
+  });
+
+  it("Execution & Verification", async function () {
+    try {
+      await nonUi5.element.getById("sdk---app--apiTab-text");
+    } catch (error) {
+      await expect(error.stack).toMatch(/at.*getById\.spec\.js/);
+    }
+
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "watch": false,
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2019" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "paths": {


### PR DESCRIPTION
 update target to es2019 in tsconfig.json to fix [issue](https://github.com/SAP/wdio-qmate-service/issues/60)

Please see webdriver issue - https://github.com/webdriverio/webdriverio/pull/8129

