### PR TITLE
circular reference error while getting ui5 aggregation property

### DIFF
--- a/src/scripts/hooks/utils/cycle.js
+++ b/src/scripts/hooks/utils/cycle.js
@@ -1,0 +1,179 @@
+/*
+    cycle.js
+    2021-05-31
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    This code should be minified before deployment.
+    See https://www.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+*/
+// modified from https://github.com/douglascrockford/JSON-js/blob/master/cycle.js
+// The file uses the WeakMap feature of ES6.
+
+/*jslint eval */
+
+/*property
+    $ref, decycle, forEach, get, indexOf, isArray, keys, length, push,
+    retrocycle, set, stringify, test
+*/
+
+module.exports = {
+  decycle: function decycle(object, replacer) {
+    "use strict";
+
+    // Make a deep copy of an object or array, assuring that there is at most
+    // one instance of each object or array in the resulting structure. The
+    // duplicate references (which might be forming cycles) are replaced with
+    // an object of the form
+
+    //      {"$ref": PATH}
+
+    // where the PATH is a JSONPath string that locates the first occurance.
+
+    // So,
+
+    //      var a = [];
+    //      a[0] = a;
+    //      return JSON.stringify(JSON.decycle(a));
+
+    // produces the string '[{"$ref":"$"}]'.
+
+    // If a replacer function is provided, then it will be called for each value.
+    // A replacer function receives a value and returns a replacement value.
+
+    // JSONPath is used to locate the unique object. $ indicates the top level of
+    // the object or array. [NUMBER] or [STRING] indicates a child element or
+    // property.
+
+    var objects = new WeakMap();     // object to path mappings
+
+    return (function derez(value, path) {
+
+      // The derez function recurses through the object, producing the deep copy.
+
+      var old_path;   // The path of an earlier occurance of value
+      var nu;         // The new object or array
+
+      // If a replacer function was provided, then call it to get a replacement value.
+
+      if (replacer !== undefined) {
+        value = replacer(value);
+      }
+
+      // typeof null === "object", so go on if this value is really an object but not
+      // one of the weird builtin objects.
+
+      if (
+        typeof value === "object"
+        && value !== null
+        && !(value instanceof Boolean)
+        && !(value instanceof Date)
+        && !(value instanceof Number)
+        && !(value instanceof RegExp)
+        && !(value instanceof String)
+      ) {
+
+        // If the value is an object or array, look to see if we have already
+        // encountered it. If so, return a {"$ref":PATH} object. This uses an
+        // ES6 WeakMap.
+
+        old_path = objects.get(value);
+        if (old_path !== undefined) {
+          return { $ref: old_path };
+        }
+
+        // Otherwise, accumulate the unique value and its path.
+
+        objects.set(value, path);
+
+        // If it is an array, replicate the array.
+
+        if (Array.isArray(value)) {
+          nu = [];
+          value.forEach(function (element, i) {
+            nu[i] = derez(element, path + "[" + i + "]");
+          });
+        } else {
+
+          // If it is an object, replicate the object.
+
+          nu = {};
+          Object.keys(value).forEach(function (name) {
+            nu[name] = derez(
+              value[name],
+              path + "[" + JSON.stringify(name) + "]"
+            );
+          });
+        }
+        return nu;
+      }
+      return value;
+    }(object, "$"));
+  },
+
+  retrocycle: function retrocycle($) {
+    "use strict";
+
+    // Restore an object that was reduced by decycle. Members whose values are
+    // objects of the form
+    //      {$ref: PATH}
+    // are replaced with references to the value found by the PATH. This will
+    // restore cycles. The object will be mutated.
+
+    // The eval function is used to locate the values described by a PATH. The
+    // root object is kept in a $ variable. A regular expression is used to
+    // assure that the PATH is extremely well formed. The regexp contains nested
+    // * quantifiers. That has been known to have extremely bad performance
+    // problems on some browsers for very long strings. A PATH is expected to be
+    // reasonably short. A PATH is allowed to belong to a very restricted subset of
+    // Goessner's JSONPath.
+
+    // So,
+    //      var s = '[{"$ref":"$"}]';
+    //      return JSON.retrocycle(JSON.parse(s));
+    // produces an array containing a single element which is the array itself.
+
+    var px = /^\$(?:\[(?:\d+|"(?:[^\\"\u0000-\u001f]|\\(?:[\\"\/bfnrt]|u[0-9a-zA-Z]{4}))*")\])*$/;
+
+    (function rez(value) {
+
+      // The rez function walks recursively through the object looking for $ref
+      // properties. When it finds one that has a value that is a path, then it
+      // replaces the $ref object with a reference to the value that is found by
+      // the path.
+
+      if (value && typeof value === "object") {
+        if (Array.isArray(value)) {
+          value.forEach(function (element, i) {
+            if (typeof element === "object" && element !== null) {
+              var path = element.$ref;
+              if (typeof path === "string" && px.test(path)) {
+                value[i] = eval(path);
+              } else {
+                rez(element);
+              }
+            }
+          });
+        } else {
+          Object.keys(value).forEach(function (name) {
+            var item = value[name];
+            if (typeof item === "object" && item !== null) {
+              var path = item.$ref;
+              if (typeof path === "string" && px.test(path)) {
+                value[name] = eval(path);
+              } else {
+                rez(item);
+              }
+            }
+          });
+        }
+      }
+    }($));
+    return $;
+  }
+};

--- a/src/scripts/hooks/utils/lib.ts
+++ b/src/scripts/hooks/utils/lib.ts
@@ -135,7 +135,7 @@ var LibScripts = function () {
           throw new Error("Eval failed:" + e);
         }
         if (aCustomParams && aCustomParams.length) {
-          return userDefFunction(control, aCustomParams.toString(), callBack);
+          return userDefFunction(control, ...aCustomParams, callBack);
         }
         return userDefFunction(control, callBack);
       };

--- a/test/core/functional/ui5Properties/countries.json
+++ b/test/core/functional/ui5Properties/countries.json
@@ -1,0 +1,282 @@
+[
+  {
+    "key": "DZ",
+    "text": "Algeria"
+  },
+  {
+    "key": "AR",
+    "text": "Argentina"
+  },
+  {
+    "key": "AU",
+    "text": "Australia"
+  },
+  {
+    "key": "AT",
+    "text": "Austria"
+  },
+  {
+    "key": "BH",
+    "text": "Bahrain"
+  },
+  {
+    "key": "BE",
+    "text": "Belgium"
+  },
+  {
+    "key": "BA",
+    "text": "Bosnia and Herzegovina"
+  },
+  {
+    "key": "BR",
+    "text": "Brazil"
+  },
+  {
+    "key": "BG",
+    "text": "Bulgaria"
+  },
+  {
+    "key": "CA",
+    "text": "Canada"
+  },
+  {
+    "key": "CL",
+    "text": "Chile"
+  },
+  {
+    "key": "CO",
+    "text": "Colombia"
+  },
+  {
+    "key": "HR",
+    "text": "Croatia"
+  },
+  {
+    "key": "CU",
+    "text": "Cuba"
+  },
+  {
+    "key": "CZ",
+    "text": "Czech Republic"
+  },
+  {
+    "key": "DK",
+    "text": "Denmark"
+  },
+  {
+    "key": "EG",
+    "text": "Egypt"
+  },
+  {
+    "key": "EE",
+    "text": "Estonia"
+  },
+  {
+    "key": "FI",
+    "text": "Finland"
+  },
+  {
+    "key": "FR",
+    "text": "France"
+  },
+  {
+    "key": "GER",
+    "text": "Germany"
+  },
+  {
+    "key": "GH",
+    "text": "Ghana"
+  },
+  {
+    "key": "GR",
+    "text": "Greece"
+  },
+  {
+    "key": "HU",
+    "text": "Hungary"
+  },
+  {
+    "key": "IN",
+    "text": "India"
+  },
+  {
+    "key": "ID",
+    "text": "Indonesia"
+  },
+  {
+    "key": "IE",
+    "text": "Ireland"
+  },
+  {
+    "key": "IL",
+    "text": "Israel"
+  },
+  {
+    "key": "IT",
+    "text": "Italy"
+  },
+  {
+    "key": "JP",
+    "text": "Japan"
+  },
+  {
+    "key": "JO",
+    "text": "Jordan"
+  },
+  {
+    "key": "KE",
+    "text": "Kenya"
+  },
+  {
+    "key": "KW",
+    "text": "Kuwait"
+  },
+  {
+    "key": "LV",
+    "text": "Latvia"
+  },
+  {
+    "key": "LT",
+    "text": "Lithuania"
+  },
+  {
+    "key": "MK",
+    "text": "Macedonia"
+  },
+  {
+    "key": "MY",
+    "text": "Malaysia"
+  },
+  {
+    "key": "MX",
+    "text": "Mexico"
+  },
+  {
+    "key": "ME",
+    "text": "Montenegro"
+  },
+  {
+    "key": "MA",
+    "text": "Morocco"
+  },
+  {
+    "key": "NL",
+    "text": "Netherlands"
+  },
+  {
+    "key": "NZ",
+    "text": "New Zealand"
+  },
+  {
+    "key": "NG",
+    "text": "Nigeria"
+  },
+  {
+    "key": "NO",
+    "text": "Norway"
+  },
+  {
+    "key": "OM",
+    "text": "Oman"
+  },
+  {
+    "key": "PE",
+    "text": "Peru"
+  },
+  {
+    "key": "PH",
+    "text": "Philippines"
+  },
+  {
+    "key": "PL",
+    "text": "Poland"
+  },
+  {
+    "key": "PT",
+    "text": "Portugal"
+  },
+  {
+    "key": "QA",
+    "text": "Qatar"
+  },
+  {
+    "key": "RO",
+    "text": "Romania"
+  },
+  {
+    "key": "RU",
+    "text": "Russia"
+  },
+  {
+    "key": "SA",
+    "text": "Saudi Arabia"
+  },
+  {
+    "key": "SN",
+    "text": "Senegal"
+  },
+  {
+    "key": "RS",
+    "text": "Serbia"
+  },
+  {
+    "key": "SG",
+    "text": "Singapore"
+  },
+  {
+    "key": "SK",
+    "text": "Slovakia"
+  },
+  {
+    "key": "SI",
+    "text": "Slovenia"
+  },
+  {
+    "key": "ZA",
+    "text": "South Africa"
+  },
+  {
+    "key": "KR",
+    "text": "South Korea"
+  },
+  {
+    "key": "ES",
+    "text": "Spain"
+  },
+  {
+    "key": "SE",
+    "text": "Sweden"
+  },
+  {
+    "key": "CH",
+    "text": "Switzerland"
+  },
+  {
+    "key": "TN",
+    "text": "Tunisia"
+  },
+  {
+    "key": "TR",
+    "text": "Turkey"
+  },
+  {
+    "key": "UG",
+    "text": "Uganda"
+  },
+  {
+    "key": "UA",
+    "text": "Ukraine"
+  },
+  {
+    "key": "AE",
+    "text": "United Arab Emirates"
+  },
+  {
+    "key": "GB",
+    "text": "United Kingdom"
+  },
+  {
+    "key": "YE",
+    "text": "Yemen"
+  }
+]

--- a/test/core/functional/ui5Properties/getAggregations.test.js
+++ b/test/core/functional/ui5Properties/getAggregations.test.js
@@ -1,5 +1,6 @@
 "use strict";
 const { handleCookiesConsent } = require("../../../helper/utils");
+const countries = require("./countries.json");
 
 describe("Test 'getAllUI5Aggregations()' and 'getUI5Aggregation()' on both element and browser levels", function () {
 
@@ -40,10 +41,12 @@ describe("Test 'getAllUI5Aggregations()' and 'getUI5Aggregation()' on both eleme
     await expect(browser.getUI5Aggregation("tooltip", element)).resolves.toEqual(tooltipOnElementLever);
 
     // Aggregation array - test in controlActionInBrowser
-    // This is not working, fails with an error "javascript error: circular reference" - maybe an infinite loop?
-    // content is an array of objects
-    await expect(element.getUI5Aggregation("items")).rejects.toThrow("javascript error: circular reference");
-    await expect(browser.getUI5Aggregation("items", element)).rejects.toThrow("javascript error: circular reference");
+    let items = await element.getUI5Aggregation("items");
+    let itemProperties = items.map(item => item.mProperties);
+    await expect(itemProperties).toMatchObject(countries);
+    items = await browser.getUI5Aggregation("items", element);
+    itemProperties = items.map(item => item.mProperties);
+    await expect(itemProperties).toMatchObject(countries);
   });
 
   it("should get List Item aggregations on both element and browser levels and access tooltip aggregation", async function () {

--- a/test/reuse/ui5/control/getAggregationProperty.spec.js
+++ b/test/reuse/ui5/control/getAggregationProperty.spec.js
@@ -1,4 +1,5 @@
 "use strict";
+const { handleCookiesConsent } = require("../../../helper/utils");
 
 describe("getAggregationProperty - check name is Accessories", async () => {
   let val;
@@ -25,5 +26,58 @@ describe("getAggregationProperty - check name is Accessories", async () => {
 
   it("Verification", () => {
     common.assertion.expectEqual(val, "Open category Accessories");
+  });
+});
+
+describe("getAggregationProperty - columns of table", async () => {
+  let val;
+  const expectedColumns = ["Product", "Supplier", "Dimensions", "Weight", "Price"];
+  it("Preparation", async () => {
+    const url = "https://sapui5.hana.ondemand.com/1.99.0/#/entity/sap.m.Table/sample/sap.m.sample.Table";
+    await common.navigation.navigateToUrl(url);
+    await handleCookiesConsent();
+  });
+
+  it("Execution", async () => {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.m.sample.Table.Table",
+        "metadata": "sap.m.Table"
+      }
+    };
+    val = await ui5.control.getAggregationProperty(selector, "columns");
+    val = val.map(item => item.mAggregations.header.mProperties.text);
+  });
+
+  it("Verification", () => {
+    common.assertion.expectEqual(val, expectedColumns);
+  });
+});
+
+describe("getAggregationProperty - items in list", async () => {
+  let val;
+  const expectedItems = ["ITelO Vault", "Notebook Basic 15", "Notebook Basic 17", "Notebook Basic 18", "Notebook Basic 19"];
+  it("Preparation", async () => {
+    const url = "https://sapui5.hana.ondemand.com/1.99.0/#/entity/sap.m.Select/sample/sap.m.sample.Select";
+    await common.navigation.navigateToUrl(url);
+    await handleCookiesConsent();
+  });
+
+  it("Execution", async () => {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.m.sample.Select.Page",
+        "metadata": "sap.m.Select",
+        "items": [{
+          "path": "/ProductCollection2"
+        }]
+      }
+    };
+    val = await ui5.control.getAggregationProperty(selector, "items");
+    val = val.map(item => item.mProperties.text);
+  });
+
+  it("Verification", () => {
+    common.assertion.expectEqual(val, expectedItems);
   });
 });


### PR DESCRIPTION
For some properties `ui5.control.getAggregationProperty` fails with "javascript error: circular reference"
E.g. `sap.m.Table` has columns property, each column has reference to the parent table, and the parent has columns, leading to circular references.
Code available here https://github.com/douglascrockford/JSON-js/blob/master/cycle.js is used to remove object references, so that webdriver can serialize the object to JSON string and return it.
This serialized object is then restored.