### PR TITLE
remove code to make file upload input visible

### DIFF
--- a/src/reuse/modules/util/file.ts
+++ b/src/reuse/modules/util/file.ts
@@ -24,15 +24,6 @@ export class File {
     try {
       if (typeof selector === "string") {
         elem = await $(selector);
-        const isDisplayed = await elem.isDisplayed();
-
-        if (!isDisplayed) {
-          await browser.execute(function (selector: string) {
-            // @ts-ignore
-            document.querySelector(selector).style.visibility = "visible";
-          }, selector);
-          await elem.waitForDisplayed();
-        }
 
       } else if (typeof selector === "object") {
         const elemId = await ui5.element.getId(selector);
@@ -42,7 +33,7 @@ export class File {
       for (const file of files) {
         const filePath = this.path.resolve(file);
         const remoteFilePath = await browser.uploadFile(filePath);
-        await elem.setValue(remoteFilePath);
+        await elem.addValue(remoteFilePath);
       }
 
     } catch (error) {

--- a/src/reuse/modules/util/file.ts
+++ b/src/reuse/modules/util/file.ts
@@ -24,7 +24,6 @@ export class File {
     try {
       if (typeof selector === "string") {
         elem = await $(selector);
-
       } else if (typeof selector === "object") {
         const elemId = await ui5.element.getId(selector);
         elem = await nonUi5.element.getByXPath(`.//input[contains(@id,'${elemId}')][@type='file']`);


### PR DESCRIPTION
In some apps the file upload input has "display:none", upload fails in those cases. Although we try setting "visibility" to "visible", "display:none" overrides that, and the input remains invisible.
If we change elem.setValue to elem.addValue, it works without requiring that the input element be visible. 
Or we can add code to make element visible by setting "display" to "block"

Fix 1:
```js
        const remoteFilePath = await browser.uploadFile(filePath);
        // change to addValue, so that it doesn't throw "element not interactable" error
        // await elem.setValue(remoteFilePath);
        await elem.addValue(remoteFilePath);
```

Fix 2: make the element visible by setting "display:block"
```js
        if (!isDisplayed) {
          await browser.execute(function (selector: string) {
            // @ts-ignore
            document.querySelector(selector).style.visibility = "visible";
             // @ts-ignore
            document.querySelector(selector).style.display = "block";
          }, selector);
          await elem.waitForDisplayed();
```