### PR TITLE
add ui5.table tests for latest ui5 version

### DIFF
--- a/test/reuse/ui5/table/clickSettingsButton.spec.js
+++ b/test/reuse/ui5/table/clickSettingsButton.spec.js
@@ -56,3 +56,59 @@ describe("table - clickSettingsButton - smartTable with tableSelector", function
   });
 
 });
+
+describe("table - clickSettingsButton - smartTable - ui5 version > 1.99.0 ", function () {
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    await ui5.table.clickSettingsButton();
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Dialog",
+        "title": "View Settings"
+      }
+    };
+    await ui5.assertion.expectToBeVisible(selector);
+  });
+
+});
+
+describe("table - clickSettingsButton - smartTable with tableSelector - ui5 version > 1.99.0", function () {
+
+  const tableSelector = {
+    "elementProperties": {
+      "metadata": "sap.ui.comp.smarttable.SmartTable"
+    }
+  };
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    await ui5.table.clickSettingsButton(tableSelector);
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Dialog",
+        "title": "View Settings"
+      }
+    };
+    await ui5.assertion.expectToBeVisible(selector);
+  });
+
+});

--- a/test/reuse/ui5/table/sortColumnAscending.spec.js
+++ b/test/reuse/ui5/table/sortColumnAscending.spec.js
@@ -82,3 +82,101 @@ describe("table - sortColumnAscending - smartTable with index (legacy)", functio
   });
 
 });
+
+describe("table - sortColumnAscending - smartTable - ui5 version > 1.99.0", function () {
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    await ui5.table.sortColumnAscending("Name");
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Column",
+        "importance": "High"
+      },
+      "descendantProperties": {
+        "metadata": "sap.m.Label",
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "text": "Name"
+      }
+    };
+    await ui5.assertion.expectAttributeToBe(selector, "sortIndicator", "Ascending");
+  });
+
+});
+
+describe("table - sortColumnAscending - smartTable with tableSelector - ui5 version > 1.99.0", function () {
+
+  const tableSelector = {
+    "elementProperties": {
+      "metadata": "sap.ui.comp.smarttable.SmartTable"
+    }
+  };
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    await ui5.table.sortColumnAscending("Name", tableSelector);
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Column",
+        "importance": "High"
+      },
+      "descendantProperties": {
+        "metadata": "sap.m.Label",
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "text": "Name"
+      },
+      "ancestorProperties": tableSelector
+    };
+    await ui5.assertion.expectAttributeToBe(selector, "sortIndicator", "Ascending");
+  });
+
+});
+
+describe("table - sortColumnAscending - smartTable with index (legacy) - ui5 version > 1.99.0", function () {
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    const index = 0; // deprecated
+    await ui5.table.sortColumnAscending("Name", index);
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Column",
+        "importance": "High"
+      },
+      "descendantProperties": {
+        "metadata": "sap.m.Label",
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "text": "Name"
+      }
+    };
+    await ui5.assertion.expectAttributeToBe(selector, "sortIndicator", "Ascending", 0);
+  });
+
+});

--- a/test/reuse/ui5/table/sortColumnDescending.spec.js
+++ b/test/reuse/ui5/table/sortColumnDescending.spec.js
@@ -82,3 +82,101 @@ describe("table - sortColumnDescending - smartTable with index (legacy)", functi
   });
 
 });
+
+describe("table - sortColumnDescending - smartTable - ui5 version > 1.99.0", function () {
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    await ui5.table.sortColumnDescending("Name");
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Column",
+        "importance": "High"
+      },
+      "descendantProperties": {
+        "metadata": "sap.m.Label",
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "text": "Name"
+      }
+    };
+    await ui5.assertion.expectAttributeToBe(selector, "sortIndicator", "Descending");
+  });
+
+});
+
+describe("table - sortColumnDescending - smartTable with tableSelector - ui5 version > 1.99.0", function () {
+
+  const tableSelector = {
+    "elementProperties": {
+      "metadata": "sap.ui.comp.smarttable.SmartTable"
+    }
+  };
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    await ui5.table.sortColumnDescending("Name", tableSelector);
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Column",
+        "importance": "High"
+      },
+      "descendantProperties": {
+        "metadata": "sap.m.Label",
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "text": "Name"
+      },
+      "ancestorProperties": tableSelector
+    };
+    await ui5.assertion.expectAttributeToBe(selector, "sortIndicator", "Descending");
+  });
+
+});
+
+describe("table - sortColumnDescending - smartTable with index (legacy) - ui5 version > 1.99.0", function () {
+
+  it("Preparation", async function () {
+    await browser.url("https://sapui5.hana.ondemand.com/#/entity/sap.ui.comp.smarttable.SmartTable/sample/sap.ui.comp.sample.smarttable.mtable");
+    await handleCookiesConsent();
+    await util.browser.switchToIframe("[id='sampleFrame']");
+  });
+
+  it("Execution", async function () {
+    const index = 0; // deprecated
+    await ui5.table.sortColumnDescending("Name", index);
+  });
+
+  it("Verification", async function () {
+    const selector = {
+      "elementProperties": {
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "metadata": "sap.m.Column",
+        "importance": "High"
+      },
+      "descendantProperties": {
+        "metadata": "sap.m.Label",
+        "viewName": "sap.ui.comp.sample.smarttable.mtable.SmartTable",
+        "text": "Name"
+      }
+    };
+    await ui5.assertion.expectAttributeToBe(selector, "sortIndicator", "Descending", 0);
+  });
+
+});


### PR DESCRIPTION
Table column headers in newer ui5 versions don't have the tooltip. We don't use tooltip value in the selectors in `ui5.table`, so `ui5.table.sortColumnAscending` and `ui5.table.sortColumnDescending` work fine with newer ui5 versions.

Current tests use ui5 version 1.99.0, and have column header selectors with tooltip value.
Since newer ui5 versions don't have tooltips for column headers, added tests for new ui5, with proper selectors.
