### PR TITLE
Custom runner commands

### DIFF
--- a/src/reuse/index.ts
+++ b/src/reuse/index.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 // functions
-import { step, stepSkip, stepRecordMode } from "./modules/runner";
+import { cit } from "./modules/runner";
 
 // modules
 import utilQmate from "./modules/util/Util";
@@ -17,11 +17,7 @@ class ReuseLibrary {
   load() {
     // Runner functions
     // @ts-ignore
-    global.step = step;
-    // @ts-ignore
-    global.stepSkip = stepSkip;
-    // @ts-ignore
-    global.stepRecordMode = stepRecordMode;
+    global.cit = cit;
 
     /**
      * @global

--- a/src/reuse/index.ts
+++ b/src/reuse/index.ts
@@ -1,5 +1,8 @@
 "use strict";
 
+// functions
+import { step, stepSkip, stepRecordMode } from "./modules/runner";
+
 // modules
 import utilQmate from "./modules/util/Util";
 import commonQmate from "./modules/common/Common";
@@ -12,6 +15,14 @@ import authenticators from "./data/authenticators.json";
 
 class ReuseLibrary {
   load() {
+    // Runner functions
+    // @ts-ignore
+    global.step = step;
+    // @ts-ignore
+    global.stepSkip = stepSkip;
+    // @ts-ignore
+    global.stepRecordMode = stepRecordMode;
+
     /**
      * @global
      * @description Global namespace for common modules.

--- a/src/reuse/modules/runner.ts
+++ b/src/reuse/modules/runner.ts
@@ -1,0 +1,19 @@
+"use strict";
+
+import { TestFunction } from "mocha";
+
+export async function step(testName: string, fn: TestFunction) {
+  it(testName, fn);
+}
+
+export async function stepSkip(testName: string, fn: TestFunction) {
+  it.skip(testName, fn);
+}
+
+export async function stepRecordMode(testName: string, fn: TestFunction) {
+  if (browser.config.params.qmateProxyService.mode === "REPLAY") {
+    it.skip(testName, fn);
+  } else {
+    it(testName, fn);
+  }
+}

--- a/src/reuse/modules/runner.ts
+++ b/src/reuse/modules/runner.ts
@@ -2,18 +2,29 @@
 
 import { TestFunction } from "mocha";
 
-export async function step(testName: string, fn: TestFunction) {
-  it(testName, fn);
-}
-
-export async function stepSkip(testName: string, fn: TestFunction) {
-  it.skip(testName, fn);
-}
-
-export async function stepRecordMode(testName: string, fn: TestFunction) {
+// Custom step type for Qmate Proxy Service -> will be skipped in REPLAY mode
+export async function cit(testName: string, fn: TestFunction) {
   if (browser.config.params.qmateProxyService.mode === "REPLAY") {
     it.skip(testName, fn);
   } else {
     it(testName, fn);
   }
 }
+
+// Keep for future custom Qmate syntax
+
+// export async function step(testName: string, fn: TestFunction) {
+//   it(testName, fn);
+// }
+
+// export async function stepSkip(testName: string, fn: TestFunction) {
+//   it.skip(testName, fn);
+// }
+
+// export async function stepRecordMode(testName: string, fn: TestFunction) {
+//   if (browser.config.params.qmateProxyService.mode === "REPLAY") {
+//     it.skip(testName, fn);
+//   } else {
+//     it(testName, fn);
+//   }
+// }


### PR DESCRIPTION
Adds custom it (cit -> component it) for Qmate Proxy which is skipped in REPLAY mode.
Can be used for login, closePopups and other functions which should only be executed in RECORD.