### PR TITLE
add response field in mockserver

### DIFF
--- a/src/reuse/modules/ui5/mockserver.ts
+++ b/src/reuse/modules/ui5/mockserver.ts
@@ -223,7 +223,9 @@ export class Mockserver {
               resHeader["location"] = responseLocation;
             }
             resHeader["Content-Type"] = "application/json;charset=utf-8";
-            oXhr.respond(parsedReturnCode, resHeader, JSON.stringify(oData));
+            const responseText = JSON.stringify(oData);
+            oXhr.response = responseText;
+            oXhr.respond(parsedReturnCode, resHeader, responseText);
           }
           return true;
         };
@@ -407,7 +409,9 @@ export class Mockserver {
               resHeader["location"] = responseLocation;
             }
             resHeader["Content-Type"] = "application/json;charset=utf-8";
-            oXhr.respond(parsedReturnCode, resHeader, JSON.stringify(oData));
+            const responseText = JSON.stringify(oData);
+            oXhr.response = responseText;
+            oXhr.respond(parsedReturnCode, resHeader, responseText);
           }
           return true;
         };


### PR DESCRIPTION
One of the reuse components (attachment service) expects "response" field to be set in mockserver.

The sinonjs version used in ui5 mockserver sets the responseText field, but not the response field - https://github.com/SAP/openui5/blob/6a2eab8426de85986e43cce3edc0214785293f5d/src/sap.ui.core/src/sap/ui/thirdparty/sinon.js#L4937

Newer versions of sinonjs set response and responseText fields to the same value - https://github.com/sinonjs/nise/blob/dd4fae3af16ce745b78dba289131c207a10a26d9/lib/fake-xhr/index.js#L789

Added the response field as a workaround, this has to be set before we call oXhr.respond, since the respond method sets the state to DONE.