### PR TITLE
remove deepmerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@wdio/static-server-service": "^8.6.8",
         "app-root-path": "^3.1.0",
         "chai": "^4.3.4",
-        "chromedriver": "^111.0.0",
+        "chromedriver": "^113.0.0",
         "concurrently": "^7.6.0",
         "doctrine": "^3.0.0",
         "eslint": "^6.8.0",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
-      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
+      "version": "113.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
+      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2369,7 +2369,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/chromium-bidi": {
@@ -19110,9 +19110,9 @@
       }
     },
     "chromedriver": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
-      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
+      "version": "113.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
+      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "@wdio/static-server-service": "^8.6.8",
     "app-root-path": "^3.1.0",
     "chai": "^4.3.4",
-    "chromedriver": "^111.0.0",
+    "chromedriver": "^113.0.0",
     "concurrently": "^7.6.0",
     "doctrine": "^3.0.0",
     "eslint": "^6.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ module.exports = class CustomWorkerService {
   // @ts-ignore
   async beforeSession(config, capabilities, specs) {
     try {
-      browser.config = deepMerge(browser.options, config);
+      browser.config = config;
       await qmateLoaderSession(config, capabilities, specs);
       this.config = browser.config;
     } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import qmateLoader from "./scripts/hooks/before";
 import onPrepareHook from "./scripts/hooks/onPrepare";
 import onCompleteHook from "./scripts/hooks/onComplete";
 import afterHook from "./scripts/hooks/after";
-import deepMerge from "deepmerge";
 const pj = require("../package.json");
 
 module.exports = class CustomWorkerService {


### PR DESCRIPTION
Removing deepmerge of browser.options and config, as config will have all the command line args itself.

Tested with appCov profile and using command line args, works fine

 ```sudo apt-get install google-chrome-stable``` installs the 113.0.0 version. So have updated the dependency