### PR TITLE
fix ui5.userInteraction.selectMultiComboBox, the last selected item gets cleared

### DIFF
--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -511,7 +511,7 @@ export class UserInteraction {
       await this.scrollToElement(ui5ControlProperties);
       await this.click(ui5ControlProperties);
     }
-    await common.userInteraction.pressEnter();
+    await common.userInteraction.pressEscape();
   }
 
   /**


### PR DESCRIPTION
The last item selected does not show up in the token list for MultiComboBox in newer version of ui5.
Fixed so that it works for older and newer versions of ui5.