### PR TITLE
fix service.odata.readPdfFromDirectUrl to throw error for 400 and 500 http status codes

### DIFF
--- a/src/reuse/modules/service/odata.ts
+++ b/src/reuse/modules/service/odata.ts
@@ -350,7 +350,7 @@ export class OData {
     return new Promise((resolve, reject) => {
       this.curl.get(url, options, function (error: any, res: any, body: any) {
         if (!error) {
-          if(res.statusCode >= 400) {
+          if (res.statusCode >= 400) {
             reject(`${res.statusCode} - ${res.statusMessage}`);
           } else {
             resolve(body);

--- a/src/reuse/modules/service/odata.ts
+++ b/src/reuse/modules/service/odata.ts
@@ -350,7 +350,11 @@ export class OData {
     return new Promise((resolve, reject) => {
       this.curl.get(url, options, function (error: any, res: any, body: any) {
         if (!error) {
-          resolve(body);
+          if(res.statusCode >= 400) {
+            reject(`${res.statusCode} - ${res.statusMessage}`);
+          } else {
+            resolve(body);
+          }
         } else {
           reject(error);
         }


### PR DESCRIPTION
In case the http request fails (4xx and 5xx return codes), this call still returns the response body, and parsing the pdf in subsequent step fails.
So check for http status code, and throw an error if the request fails.