### PR TITLE
Replaced addValue to setValue for file upload

### DIFF
--- a/src/reuse/modules/util/file.ts
+++ b/src/reuse/modules/util/file.ts
@@ -44,7 +44,7 @@ export class File {
         const filePath = path.resolve(file);
         vl.log(`Uploading file with a path ${filePath}`);
         const remoteFilePath = await browser.uploadFile(filePath);
-        await elem.addValue(remoteFilePath);
+        await elem.setValue(remoteFilePath);
       }
     } catch (error) {
       throw new Error(`Function 'upload' failed': ${error}`);


### PR DESCRIPTION
const remoteFilePath = await browser.uploadFile(filePath);
await elem.addValue(remoteFilePath);  

addValue method will not clear the textbox so in first iteration it will upload one file **test.txt** and in second iteration it will upload new file **test1.txt** along with **test.txt** because this file already exist in textbox so we can see duplicate of file upload.

if we use the below this things in place of addValue it will work as expected
await elem.setValue(remoteFilePath);