### PR TITLE
Fix util.file.upload for cases where file input is not visible or interactable

### DIFF
--- a/src/reuse/modules/util/file.ts
+++ b/src/reuse/modules/util/file.ts
@@ -39,13 +39,17 @@ export class File {
         const elemId = await ui5.element.getId(selector);
         elem = await nonUi5.element.getByXPath(`.//input[contains(@id,'${elemId}')][@type='file']`);
       }
-
+      let remoteFiles = "";
       for (const file of files) {
         const filePath = path.resolve(file);
         vl.log(`Uploading file with a path ${filePath}`);
         const remoteFilePath = await browser.uploadFile(filePath);
-        await elem.setValue(remoteFilePath);
+        if (remoteFiles) {
+          remoteFiles = remoteFiles + "\n";
+        }
+        remoteFiles = remoteFiles + remoteFilePath;
       }
+      await elem.addValue(remoteFiles);
     } catch (error) {
       throw new Error(`Function 'upload' failed': ${error}`);
     }


### PR DESCRIPTION
elem.setValue gives "element not interactable" error if file input is not visible in chrome.
In firefox changing visibility doesn't help, so switched to elem.addValue