### PR TITLE
adjust default alignment for non ui5 scroll

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1763,7 +1763,7 @@ Global namespace for UI5 modules.
         * [.clickSelectArrowAndRetry(selector, [index], [retries], [interval])](#ui5.userInteraction.clickSelectArrowAndRetry)
         * [.selectFromTab(selector, value, [index], [timeout])](#ui5.userInteraction.selectFromTab)
         * [.mouseOverElement(selector, [index], [timeout])](#ui5.userInteraction.mouseOverElement)
-        * [.scrollToElement(selector, [index], [alignment], [timeout])](#ui5.userInteraction.scrollToElement)
+        * [.scrollToElement(selector, [index], [alignment])](#ui5.userInteraction.scrollToElement)
         * [.selectAll([selector], [index], [timeout])](#ui5.userInteraction.selectAll)
         * [.openF4Help(selector, [index], [timeout], useF4Key)](#ui5.userInteraction.openF4Help)
         * [.searchFor(selector, [index], [timeout], useEnter)](#ui5.userInteraction.searchFor)
@@ -3684,7 +3684,7 @@ await ui5.table.clickSettingsButton(glAccountItemsTable);
     * [.clickSelectArrowAndRetry(selector, [index], [retries], [interval])](#ui5.userInteraction.clickSelectArrowAndRetry)
     * [.selectFromTab(selector, value, [index], [timeout])](#ui5.userInteraction.selectFromTab)
     * [.mouseOverElement(selector, [index], [timeout])](#ui5.userInteraction.mouseOverElement)
-    * [.scrollToElement(selector, [index], [alignment], [timeout])](#ui5.userInteraction.scrollToElement)
+    * [.scrollToElement(selector, [index], [alignment])](#ui5.userInteraction.scrollToElement)
     * [.selectAll([selector], [index], [timeout])](#ui5.userInteraction.selectAll)
     * [.openF4Help(selector, [index], [timeout], useF4Key)](#ui5.userInteraction.openF4Help)
     * [.searchFor(selector, [index], [timeout], useEnter)](#ui5.userInteraction.searchFor)
@@ -4129,8 +4129,8 @@ await ui5.userInteraction.mouseOverElement(selector);
 ```
 <a name="ui5.userInteraction.scrollToElement"></a>
 
-#### userInteraction.scrollToElement(selector, [index], [alignment], [timeout])
-Scrolls to the element with the given selector to get it into view.
+#### userInteraction.scrollToElement(selector, [index], [alignment])
+Scrolls the element with the given selector into view.
 
 **Kind**: static method of [<code>userInteraction</code>](#ui5.userInteraction)  
 
@@ -4138,16 +4138,21 @@ Scrolls to the element with the given selector to get it into view.
 | --- | --- | --- | --- |
 | selector | <code>Object</code> |  | The selector describing the element. |
 | [index] | <code>Number</code> | <code>0</code> | The index of the selector (in case there are more than one elements visible at the same time). |
-| [alignment] | <code>String</code> | <code>&quot;center&quot;</code> | Defines vertical/horizontal alignment. One of "start", "center", "end", or "nearest". Affects the alignToTop parameter of scrollIntoView function. By default, it takes 'up' |
-| [timeout] | <code>Number</code> | <code>30000</code> | The timeout to wait (ms). |
+| [alignment] | <code>String</code> \| <code>Object</code> | <code>&quot;center&quot;</code> | The alignment option for scrolling.   Can be one of: "start", "center", "end", "nearest", or an object with properties:   - block: Vertical alignment ("start", "center", "end", "nearest").   - inline: Horizontal alignment ("start", "center", "end", "nearest"). |
 
 **Example**  
 ```js
-await ui5.userInteraction.scrollToElement(selector);
+// Scroll to element with center alignment.
+await nonUi5.userInteraction.scrollToElement(selector, 0, "center");
 ```
 **Example**  
 ```js
-await ui5.userInteraction.scrollToElement(selector, 0, "start", 5000);
+// Scroll to element with custom alignment.
+const alignment = {
+  block: "start",
+  inline: "center"
+};
+await nonUi5.userInteraction.scrollToElement(selector, 0, alignment);
 ```
 <a name="ui5.userInteraction.selectAll"></a>
 
@@ -4276,7 +4281,7 @@ Global namespace for non UI5 modules.
         * [.clearAndFill(element, value)](#nonUi5.userInteraction.clearAndFill)
         * [.clearAndFillAndRetry(element, value, [retries], [interval], [verify])](#nonUi5.userInteraction.clearAndFillAndRetry)
         * [.mouseOverElement(element, [xOffset], [yOffset])](#nonUi5.userInteraction.mouseOverElement)
-        * [.scrollToElement(elem, alignment)](#nonUi5.userInteraction.scrollToElement)
+        * [.scrollToElement(elem, [alignment])](#nonUi5.userInteraction.scrollToElement)
         * [.dragAndDrop(element, targetElem)](#nonUi5.userInteraction.dragAndDrop)
         * [.moveCursorAndClick(element)](#nonUi5.userInteraction.moveCursorAndClick)
         * [.clickElementInSvg(svgElem, innerSelector)](#nonUi5.userInteraction.clickElementInSvg)
@@ -4921,7 +4926,7 @@ await nonUi5.session.loginSapNetWeaver("john", "abc123!");
     * [.clearAndFill(element, value)](#nonUi5.userInteraction.clearAndFill)
     * [.clearAndFillAndRetry(element, value, [retries], [interval], [verify])](#nonUi5.userInteraction.clearAndFillAndRetry)
     * [.mouseOverElement(element, [xOffset], [yOffset])](#nonUi5.userInteraction.mouseOverElement)
-    * [.scrollToElement(elem, alignment)](#nonUi5.userInteraction.scrollToElement)
+    * [.scrollToElement(elem, [alignment])](#nonUi5.userInteraction.scrollToElement)
     * [.dragAndDrop(element, targetElem)](#nonUi5.userInteraction.dragAndDrop)
     * [.moveCursorAndClick(element)](#nonUi5.userInteraction.moveCursorAndClick)
     * [.clickElementInSvg(svgElem, innerSelector)](#nonUi5.userInteraction.clickElementInSvg)
@@ -5153,20 +5158,31 @@ await nonUi5.userInteraction.mouseOverElement(elem);
 ```
 <a name="nonUi5.userInteraction.scrollToElement"></a>
 
-#### userInteraction.scrollToElement(elem, alignment)
-Scrolls to the passed element to get it into view.
+#### userInteraction.scrollToElement(elem, [alignment])
+Scrolls an element into view.
 
 **Kind**: static method of [<code>userInteraction</code>](#nonUi5.userInteraction)  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| elem | <code>Object</code> |  | The element. |
-| alignment | <code>String</code> | <code>&quot;center&quot;</code> | Defines vertical/horizontal alignment. One of "start", "center", "end", or "nearest". Affects the alignToTop parameter of scrollIntoView function. By default, it takes 'up' |
+| elem | <code>Element</code> |  | The target element to scroll to. |
+| [alignment] | <code>String</code> \| <code>Object</code> | <code>&quot;center&quot;</code> | The alignment option for scrolling.   Can be one of: "start", "center", "end", "nearest", or an object with properties:   - block: Vertical alignment ("start", "center", "end", "nearest").   - inline: Horizontal alignment ("start", "center", "end", "nearest"). |
 
 **Example**  
 ```js
+// Scroll to element with center alignment.
 const elem = await nonUi5.userInteraction.getElementById("footer01");
-await nonUi5.userInteraction.scrollToElement(elem);
+await nonUi5.userInteraction.scrollToElement(elem, "center");
+```
+**Example**  
+```js
+// Scroll to element with custom alignment.
+const elem = await nonUi5.userInteraction.getElementById("footer01");
+const alignment = {
+  block: "start",
+  inline: "center"
+};
+await nonUi5.userInteraction.scrollToElement(elem, alignment);
 ```
 <a name="nonUi5.userInteraction.dragAndDrop"></a>
 

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -1763,7 +1763,7 @@ Global namespace for UI5 modules.
         * [.clickSelectArrowAndRetry(selector, [index], [retries], [interval])](#ui5.userInteraction.clickSelectArrowAndRetry)
         * [.selectFromTab(selector, value, [index], [timeout])](#ui5.userInteraction.selectFromTab)
         * [.mouseOverElement(selector, [index], [timeout])](#ui5.userInteraction.mouseOverElement)
-        * [.scrollToElement(selector, [index], [alignment])](#ui5.userInteraction.scrollToElement)
+        * [.scrollToElement(selector, [index], [alignment], [timeout])](#ui5.userInteraction.scrollToElement)
         * [.selectAll([selector], [index], [timeout])](#ui5.userInteraction.selectAll)
         * [.openF4Help(selector, [index], [timeout], useF4Key)](#ui5.userInteraction.openF4Help)
         * [.searchFor(selector, [index], [timeout], useEnter)](#ui5.userInteraction.searchFor)
@@ -3684,7 +3684,7 @@ await ui5.table.clickSettingsButton(glAccountItemsTable);
     * [.clickSelectArrowAndRetry(selector, [index], [retries], [interval])](#ui5.userInteraction.clickSelectArrowAndRetry)
     * [.selectFromTab(selector, value, [index], [timeout])](#ui5.userInteraction.selectFromTab)
     * [.mouseOverElement(selector, [index], [timeout])](#ui5.userInteraction.mouseOverElement)
-    * [.scrollToElement(selector, [index], [alignment])](#ui5.userInteraction.scrollToElement)
+    * [.scrollToElement(selector, [index], [alignment], [timeout])](#ui5.userInteraction.scrollToElement)
     * [.selectAll([selector], [index], [timeout])](#ui5.userInteraction.selectAll)
     * [.openF4Help(selector, [index], [timeout], useF4Key)](#ui5.userInteraction.openF4Help)
     * [.searchFor(selector, [index], [timeout], useEnter)](#ui5.userInteraction.searchFor)
@@ -4129,7 +4129,7 @@ await ui5.userInteraction.mouseOverElement(selector);
 ```
 <a name="ui5.userInteraction.scrollToElement"></a>
 
-#### userInteraction.scrollToElement(selector, [index], [alignment])
+#### userInteraction.scrollToElement(selector, [index], [alignment], [timeout])
 Scrolls the element with the given selector into view.
 
 **Kind**: static method of [<code>userInteraction</code>](#ui5.userInteraction)  
@@ -4139,6 +4139,7 @@ Scrolls the element with the given selector into view.
 | selector | <code>Object</code> |  | The selector describing the element. |
 | [index] | <code>Number</code> | <code>0</code> | The index of the selector (in case there are more than one elements visible at the same time). |
 | [alignment] | <code>String</code> \| <code>Object</code> | <code>&quot;center&quot;</code> | The alignment option for scrolling.   Can be one of: "start", "center", "end", "nearest", or an object with properties:   - block: Vertical alignment ("start", "center", "end", "nearest").   - inline: Horizontal alignment ("start", "center", "end", "nearest"). |
+| [timeout] | <code>Number</code> | <code>30000</code> | The timeout to wait (ms). |
 
 **Example**  
 ```js

--- a/src/reuse/modules/nonUi5/userInteraction.ts
+++ b/src/reuse/modules/nonUi5/userInteraction.ts
@@ -394,26 +394,41 @@ export class UserInteraction {
   /**
    * @function scrollToElement
    * @memberOf nonUi5.userInteraction
-   * @description Scrolls to the passed element to get it into view.
-   * @param {Object} elem - The element.
-   * @param {String | Object} [alignment = {"block": "start", "inline" : "nearest" }] - alignment="center" - Defines vertical/horizontal alignment. One of "start", "center", "end", or "nearest".
-   * @example const elem = await nonUi5.userInteraction.getElementById("footer01");
-   * await nonUi5.userInteraction.scrollToElement(elem);
+   * @description Scrolls an element into view.
+   * @param {Element} elem - The target element to scroll to.
+   * @param {String | Object} [alignment="center"] - The alignment option for scrolling.
+   *   Can be one of: "start", "center", "end", "nearest", or an object with properties:
+   *   - block: Vertical alignment ("start", "center", "end", "nearest").
+   *   - inline: Horizontal alignment ("start", "center", "end", "nearest").
+   *
+   * @example
+   * // Scroll to element with center alignment.
+   * const elem = await nonUi5.userInteraction.getElementById("footer01");
+   * await nonUi5.userInteraction.scrollToElement(elem, "center");
+   *
+   * @example
+   * // Scroll to element with custom alignment.
+   * const elem = await nonUi5.userInteraction.getElementById("footer01");
+   * const alignment = {
+   *   block: "start",
+   *   inline: "center"
+   * };
+   * await nonUi5.userInteraction.scrollToElement(elem, alignment);
    */
-  async scrollToElement(element: Element, alignment: AlignmentOptions | AlignmentValues = { "block": "start" , "inline" : "nearest" } ) {
+
+  async scrollToElement(element: Element, alignment: AlignmentOptions | AlignmentValues = "center") {
     const vl = this.vlf.initLog(this.scrollToElement);
     let options = {};
 
     try {
       this._verifyElement(element);
-      if(typeof alignment === "string") {
+      if (typeof alignment === "string") {
         options = {
           block: alignment,
           inline: alignment
         };
-      }
-      else if(typeof alignment === "object") {
-        options = alignment
+      } else if (typeof alignment === "object") {
+        options = alignment;
       }
       vl.log("Scrolling to element");
       await element.scrollIntoView(options);

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -615,27 +615,38 @@ export class UserInteraction {
   /**
    * @function scrollToElement
    * @memberOf ui5.userInteraction
-   * @description Scrolls to the element with the given selector to get it into view.
+   * @description Scrolls the element with the given selector into view.
    * @param {Object} selector - The selector describing the element.
    * @param {Number} [index=0] - The index of the selector (in case there are more than one elements visible at the same time).
-   * @param {String | Object} [alignment="center"] - Defines vertical/horizontal alignment. One of "start", "center", "end", or "nearest".
-   * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example await ui5.userInteraction.scrollToElement(selector);
-   * @example await ui5.userInteraction.scrollToElement(selector, 0, "start", 5000);
+   * @param {String | Object} [alignment="center"] - The alignment option for scrolling.
+   *   Can be one of: "start", "center", "end", "nearest", or an object with properties:
+   *   - block: Vertical alignment ("start", "center", "end", "nearest").
+   *   - inline: Horizontal alignment ("start", "center", "end", "nearest").
+   *
+   * @example
+   * // Scroll to element with center alignment.
+   * await nonUi5.userInteraction.scrollToElement(selector, 0, "center");
+   *
+   * @example
+   * // Scroll to element with custom alignment.
+   * const alignment = {
+   *   block: "start",
+   *   inline: "center"
+   * };
+   * await nonUi5.userInteraction.scrollToElement(selector, 0, alignment);
    */
-  async scrollToElement(selector: any, index = 0, alignment: AlignmentOptions | AlignmentValues = "center" , timeout = process.env.QMATE_CUSTOM_TIMEOUT || 30000) {
+  async scrollToElement(selector: any, index = 0, alignment: AlignmentOptions | AlignmentValues = "center", timeout = process.env.QMATE_CUSTOM_TIMEOUT || 30000) {
     const vl = this.vlf.initLog(this.scrollToElement);
     let options = {};
     const elem = await ui5.element.getDisplayed(selector, index, timeout);
     if (elem) {
-      if(typeof alignment == "string") {
+      if (typeof alignment == "string") {
         options = {
           block: alignment,
           inline: alignment
         };
-      }
-      else if(typeof alignment === "object") {
-        options = alignment
+      } else if (typeof alignment === "object") {
+        options = alignment;
       }
       await elem.scrollIntoView(options);
     }

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -622,6 +622,7 @@ export class UserInteraction {
    *   Can be one of: "start", "center", "end", "nearest", or an object with properties:
    *   - block: Vertical alignment ("start", "center", "end", "nearest").
    *   - inline: Horizontal alignment ("start", "center", "end", "nearest").
+   * @param {Number} [timeout=30000] - The timeout to wait (ms).
    *
    * @example
    * // Scroll to element with center alignment.


### PR DESCRIPTION
Since some users are facing regression issues, we have to switch back to the previous default value entering the scroll.

Related NEW Issue: https://github.tools.sap/sProcurement/qmate/issues/426

Will inform author of previous issue, to manually change the alignment: https://github.tools.sap/sProcurement/qmate/issues/360