### PR TITLE
fix odata auth type

### DIFF
--- a/src/reuse/modules/service/odata.ts
+++ b/src/reuse/modules/service/odata.ts
@@ -68,7 +68,7 @@ export class OData {
    *
    * const srv = await service.odata.init(url, user, password, true, params, "headers", authHeaders);
    */
-  async init(url: string, username: string, password: string, loggingEnabled = false, params = {}, authType: string = "", headers?: any): Promise<any> {
+  async init(url: string, username: string, password: string, loggingEnabled = false, params = {}, authType?: string, headers?: any): Promise<any> {
     const logger = {
       trace: () => {},
       debug: console.debug,
@@ -87,10 +87,10 @@ export class OData {
     };
 
     const auth: any = {
-      type: authType ?? "",
       username,
       password
     };
+    if (authType) auth.type = authType;
     if (headers && Object.entries(headers).length > 0) auth.headers = headers;
 
     const srv = new this.Service({


### PR DESCRIPTION
Hotfix for: https://teams.microsoft.com/l/message/19:c261bfb56aa2485ba5809065a08f5bd7@thread.tacv2/1705495800628?tenantId=42f7676c-f455-423c-82f6-dc2d99791af7&groupId=fde8cc7b-ce3d-45b0-bb00-de7b75fde1da&parentMessageId=1705495800628&teamName=Qmate%20Test%20Automation&channelName=Consulting&createdTime=1705495800628

With the latest changes I have changed the behaviour if no value was passed to the authType which is causing some regression now. This change should fix the issue and only sets the type if the authType is passed.