### PR TITLE
Fix query params handling

### DIFF
--- a/src/reuse/modules/ui5/navigation.ts
+++ b/src/reuse/modules/ui5/navigation.ts
@@ -54,8 +54,9 @@ export class Navigation {
     }
 
     // Construct the url with the intent and query params
-    const constructedParams = this._constructUrlParams(queryParams);
-    const urlWithParams = `${baseUrlNormalized}?${constructedParams}#${intentNormalized}`;
+    let constructedParams = this._constructUrlParams(queryParams);
+    if (constructedParams !== "") constructedParams = `?${constructedParams}`;
+    const urlWithParams = `${baseUrlNormalized}${constructedParams}#${intentNormalized}`;
     vl.log(`Url with params: ${urlWithParams}`);
 
     try {
@@ -168,7 +169,16 @@ export class Navigation {
     const vl = this.vlf.initLog(this.navigateToApplicationWithQueryParams);
     let url;
     try {
-      await browser.url(`${browser.config.baseUrl}${queryParams}#${intent}`);
+      let parsedQueryParams = "";
+      if (queryParams) {
+        if (queryParams.startsWith("?")) {
+          parsedQueryParams = queryParams;
+        } else {
+          parsedQueryParams = `?${queryParams}`;
+        }
+      }
+
+      await browser.url(`${browser.config.baseUrl}${parsedQueryParams}#${intent}`);
       url = await browser.getUrl();
       await util.browser.logCurrentUrl();
       if (url && url.indexOf(intent) === -1 && verify) {

--- a/test/reuse/ui5/navigation/navigateToApplication.spec.js
+++ b/test/reuse/ui5/navigation/navigateToApplication.spec.js
@@ -1,148 +1,114 @@
 "use strict";
 
-describe("navigation - navigateToApplication with preventPopups=false", function () {
-  it("Execution & Verification", async function () {
-    // First navigation - to #Shell-home
-    let urlExpected = `${await util.browser.getBaseUrl()}#Shell-home`; // http://localhost:34099/ui#Shell-home
+// Tests to add:
+// - test with preventPopups=false
+// - test with preventPopups=true
+// - test where baseUrl has query parameters
+// - test where intent has query parameters
+// - test where baseUrl has multiple query parameters
+// - test with error handling
 
-    await ui5.navigation.navigateToApplication("Shell-home"); // preventPopups=false by default
-    let button = await nonUi5.element.getById("parseUrl");
-    await nonUi5.userInteraction.click(button);
+const BASE_URL = `http://localhost:34099/ui`;
+const INTENT = "Shell-home";
+const DUMMY_QUERY_PARAM = "dummyQueryParam=dummyValue";
+const PREVENT_POPUP_QUERY_PARAMS = "help-readCatalog=false&help-stateUACP=PRODUCTION";
 
-    await common.assertion.expectUrlToBe(urlExpected);
-
-    let parsedUrlElement = await nonUi5.element.getById("navigationUrl");
-    let parsedUrlValue = await nonUi5.element.getValue(parsedUrlElement);
-
-    await common.assertion.expectEqual(urlExpected, parsedUrlValue);
-
-    // Second navigation - to #PurchaseOrder-manage
-    urlExpected = `${await util.browser.getBaseUrl()}#PurchaseOrder-manage`; // http://localhost:34099/ui#PurchaseOrder-manage
-
-    await ui5.navigation.navigateToApplication("PurchaseOrder-manage"); // preventPopups=false by default
-    button = await nonUi5.element.getById("parseUrl");
-    await nonUi5.userInteraction.click(button);
-
-    await common.assertion.expectUrlToBe(urlExpected);
-
-    parsedUrlElement = await nonUi5.element.getById("navigationUrl");
-    parsedUrlValue = await nonUi5.element.getValue(parsedUrlElement);
-
-    await common.assertion.expectEqual(urlExpected, parsedUrlValue);
-
-  });
-});
-
-describe("navigation - navigateToApplication with preventPopups=true", function () {
-  it("Execution & Verification", async function () {
-    // First navigation - to #Shell-home
-    // "http://localhost:34099/ui?help-readCatalog=false&help-stateUACP=PRODUCTION#Shell-home" - as preventPopups=true
-    const queryToClosePopups = "help-readCatalog=false&help-stateUACP=PRODUCTION"; // from private function 'generateUrlParams'
-    let urlExpected = `${await util.browser.getBaseUrl()}?${queryToClosePopups}#Shell-home`;
-
-    await ui5.navigation.navigateToApplication("Shell-home", true); // preventPopups=true
-    let button = await nonUi5.element.getById("parseUrl");
-    await nonUi5.userInteraction.click(button);
-
-    await common.assertion.expectUrlToBe(urlExpected);
-
-    let parsedUrlElement = await nonUi5.element.getById("navigationUrl");
-    let parsedUrlValue = await nonUi5.element.getValue(parsedUrlElement);
-
-    await common.assertion.expectEqual(urlExpected, parsedUrlValue);
-
-    // Second navigation - to #PurchaseOrder-manage
-    // "http://localhost:34099/ui?help-readCatalog=false&help-stateUACP=PRODUCTION#PurchaseOrder-manage" - as preventPopups=true
-    urlExpected = `${await util.browser.getBaseUrl()}?${queryToClosePopups}#PurchaseOrder-manage`;
-
-    await ui5.navigation.navigateToApplication("PurchaseOrder-manage", true); // preventPopups=true
-    button = await nonUi5.element.getById("parseUrl");
-    await nonUi5.userInteraction.click(button);
-
-    await common.assertion.expectUrlToBe(urlExpected);
-
-    parsedUrlElement = await nonUi5.element.getById("navigationUrl");
-    parsedUrlValue = await nonUi5.element.getValue(parsedUrlElement);
-
-    await common.assertion.expectEqual(urlExpected, parsedUrlValue);
-
-  });
-});
-
-describe("navigation - navigateToApplication wrong navigation intent type with/without verification(unhappy case)", function () {
-  const wrongApplication = { strange: "intent" };
-  const application = "Shell-home";
-
-  it("Execution & Verification", async function () {
-    await ui5.navigation.navigateToApplication(application, true);
-
-    await ui5.navigation.navigateToApplication(wrongApplication, false); // verify=false - no verification
-    const currentUrl = await browser.getUrl();
-
-    // system first navigates to '<urlToSystem>#%5Bobject%20Object%5D'
-    expect(currentUrl).toContain(browser.config.baseUrl + "#[object%20Object]");
-
-    await expect(ui5.navigation.navigateToApplication(wrongApplication, false, true)) // verify = true,
-      .rejects.toThrow(/Navigation failed/);
-  });
-});
-
-
-const selectorForErrorPopupText = {
-  "elementProperties": {
-    "metadata": "sap.m.Text",
-    "ancestorProperties": {
-      "elementProperties": {
-        "metadata": "sap.m.Dialog",
-        "type": "Message",
-        "state": "Error"
-      }
-    }
-  }
-};
-
-// Test is unstable - system itself can close the popup
-// TODO: discuss local server usage for assertion tests execution
-describe.skip("assertion - expectUnsupportedNavigationPopup", function () {
+describe("navigation - navigateToApplication - preventPopups=false", function () {
   it("Preparation", async function () {
-    await ui5.navigation.navigateToApplication("Shell-home", true);
-    await ui5.session.loginFiori("PURCHASER", "super-duper-sensitive-pw");
+    browser.config.baseUrl = BASE_URL;
   });
 
   it("Execution", async function () {
-    await ui5.navigation.navigateToApplication("SomeWrong-intent", true);
+    await ui5.navigation.navigateToApplication(INTENT, false);
   });
 
   it("Verification", async function () {
-    await ui5.assertion.expectUnsupportedNavigationPopup("#SomeWrong-intent");
-  });
-
-  it("Clean Up", async function () {
-    await ui5.session.logout();
+    const urlExp = `${BASE_URL}#Shell-home`;
+    await common.assertion.expectUrlToBe(urlExp);
   });
 });
 
-// Test is unstable - system itself can close the popup
-// TODO: discuss local server usage for assertion tests execution
-describe.skip("assertion - expectUnsupportedNavigationPopup with '&' (unhappy case, another error popup)", function () {
+describe("navigation - navigateToApplication - preventPopups=true", function () {
   it("Preparation", async function () {
-    await ui5.navigation.navigateToApplication("Shell-home", true);
-    await ui5.session.loginFiori("PURCHASER", "super-duper-sensitive-pw");
+    browser.config.baseUrl = BASE_URL;
   });
 
   it("Execution", async function () {
-    await ui5.navigation.navigateToApplication("SomeWrongIntentWith&", false);
+    await ui5.navigation.navigateToApplication(INTENT, true);
   });
 
   it("Verification", async function () {
-    await expect(ui5.assertion.expectUnsupportedNavigationPopup("#SomeWrongIntentWith&"))
-      .rejects.toThrow(/No visible elements found/);
-    const textElement = await ui5.element.getDisplayed(selectorForErrorPopupText);
-    const text = await textElement.getText();
-    await common.assertion.expectEqual(text, "Could not open app. Please try again later.");
+    const urlExp = `${BASE_URL}?${PREVENT_POPUP_QUERY_PARAMS}#Shell-home`;
+    await common.assertion.expectUrlToBe(urlExp);
+  });
+});
+
+describe("navigation - navigateToApplication - baseUrl with closePopup query parameters", function () {
+  it("Preparation", async function () {
+    browser.config.baseUrl = `${BASE_URL}?${PREVENT_POPUP_QUERY_PARAMS}`;
   });
 
-  it("Clean Up", async function () {
-    await ui5.session.logout();
+  it("Execution", async function () {
+    await ui5.navigation.navigateToApplication(INTENT, false);
+  });
+
+  it("Verification", async function () {
+    const urlExp = `${BASE_URL}?${PREVENT_POPUP_QUERY_PARAMS}#Shell-home`;
+    await common.assertion.expectUrlToBe(urlExp);
+  });
+});
+
+describe("navigation - navigateToApplication - baseUrl with dummy query parameters", function () {
+  it("Preparation", async function () {
+    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM}`;
+  });
+
+  it("Execution", async function () {
+    await ui5.navigation.navigateToApplication(INTENT, false);
+  });
+
+  it("Verification", async function () {
+    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM}#Shell-home`;
+    await common.assertion.expectUrlToBe(urlExp);
+  });
+});
+
+describe("navigation - navigateToApplication - intent with dummy query parameters", function () {
+  it("Preparation", async function () {
+    browser.config.baseUrl = BASE_URL;
+  });
+
+  it("Execution", async function () {
+    await ui5.navigation.navigateToApplication(`${INTENT}?${DUMMY_QUERY_PARAM}`, false);
+  });
+
+  it("Verification", async function () {
+    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM}#Shell-home`;
+    await common.assertion.expectUrlToBe(urlExp);
+  });
+});
+
+describe("navigation - navigateToApplication - baseUrl with multiple query parameters", function () {
+  it("Preparation", async function () {
+    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM}&${PREVENT_POPUP_QUERY_PARAMS}`;
+  });
+
+  it("Execution", async function () {
+    await ui5.navigation.navigateToApplication(INTENT, false);
+  });
+
+  it("Verification", async function () {
+    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM}&${PREVENT_POPUP_QUERY_PARAMS}#Shell-home`;
+    await common.assertion.expectUrlToBe(urlExp);
+  });
+});
+
+describe("navigation - navigateToApplication - verify=true", function () {
+  it("Preparation", async function () {
+    browser.config.baseUrl = BASE_URL;
+  });
+
+  it("Execution & Verification", async function () {
+    await ui5.navigation.navigateToApplication(INTENT, false, true);
   });
 });

--- a/test/reuse/ui5/navigation/navigateToApplicationAndRetry.spec.js
+++ b/test/reuse/ui5/navigation/navigateToApplicationAndRetry.spec.js
@@ -33,7 +33,6 @@ describe("navigation - navigateToApplicationAndRetry with closePopups=true", fun
     parsedUrlValue = await nonUi5.element.getValue(parsedUrlElement);
 
     await common.assertion.expectEqual(urlExpected, parsedUrlValue);
-
   });
 });
 
@@ -68,86 +67,5 @@ describe("navigation - navigateToApplicationAndRetry with closePopups=false", fu
     parsedUrlValue = await nonUi5.element.getValue(parsedUrlElement);
 
     await common.assertion.expectEqual(urlExpected, parsedUrlValue);
-
-  });
-});
-
-describe("navigation - navigateToApplicationAndRetry wrong navigation intent type with/without verification(unhappy case)", function () {
-  const wrongApplication = {
-    strange: "intent"
-  };
-  const application = "Shell-home";
-
-  it("Execution & Verification", async function () {
-    await ui5.navigation.navigateToApplicationAndRetry(application, false, true); // closePopups=false, verify=true
-
-    await ui5.navigation.navigateToApplicationAndRetry(wrongApplication, false, false); // closePopups=false, verify=false - no verification
-    const currentUrl = await browser.getUrl();
-
-    // system first navigates to '<urlToSystem>#%5Bobject%20Object%5D'
-    expect(currentUrl).toContain(browser.config.baseUrl + "#[object%20Object]");
-
-    await expect(ui5.navigation.navigateToApplicationAndRetry(wrongApplication, false, true)) // verify = true,
-      .rejects.toThrow(/failed/);
-  });
-});
-
-
-const selectorForErrorPopupText = {
-  "elementProperties": {
-    "metadata": "sap.m.Text",
-    "ancestorProperties": {
-      "elementProperties": {
-        "metadata": "sap.m.Dialog",
-        "type": "Message",
-        "state": "Error"
-      }
-    }
-  }
-};
-
-// Test is unstable - system itself can close the popup
-// TODO: discuss local server usage for assertion tests execution
-describe.skip("assertion - expectUnsupportedNavigationPopup", function () {
-  it("Preparation", async function () {
-    await ui5.navigation.navigateToApplicationAndRetry("Shell-home", true);
-    await ui5.session.loginFiori("PURCHASER", "super-duper-sensitive-pw");
-  });
-
-  it("Execution", async function () {
-    await ui5.navigation.navigateToApplicationAndRetry("SomeWrong-intent", false);
-  });
-
-  it("Verification", async function () {
-    await ui5.assertion.expectUnsupportedNavigationPopup("#SomeWrong-intent");
-  });
-
-  it("Clean Up", async function () {
-    await ui5.session.logout();
-  });
-});
-
-// Test is unstable - system itself can close the popup
-// TODO: discuss local server usage for assertion tests execution
-describe.skip("assertion - expectUnsupportedNavigationPopup with '&' (unhappy case, another error popup)", function () {
-  it("Preparation", async function () {
-    await ui5.navigation.navigateToApplicationAndRetry("Shell-home", true);
-    await ui5.session.loginFiori("PURCHASER", "super-duper-sensitive-pw");
-  });
-
-  it("Execution", async function () {
-    await ui5.navigation.navigateToApplicationAndRetry("SomeWrongIntentWith&", false);
-  });
-
-  it("Verification", async function () {
-    await expect(ui5.assertion.expectUnsupportedNavigationPopup("#SomeWrongIntentWith&"))
-      .rejects.toThrow(/No visible elements found/);
-    const textElement = await ui5.element.getDisplayed(selectorForErrorPopupText);
-    const text = await textElement.getText();
-    await common.assertion.expectEqual(text, "Could not open app. Please try again later.");
-  });
-
-  it("Clean Up", async function () {
-    await ui5.session.logout();
   });
 });

--- a/test/reuse/ui5/navigation/navigateToApplicationWithQueryParams.spec.js
+++ b/test/reuse/ui5/navigation/navigateToApplicationWithQueryParams.spec.js
@@ -19,31 +19,6 @@ describe("navigation - navigateToApplicationWithQueryParams with query param in 
   });
 });
 
-describe("navigation - navigateToApplicationWithQueryParams with wrong param in url", function () {
-  const query = "unknownParam=value"; // query without '?' mark
-  const intent = "PurchaseOrder-manage";
-
-  it("Preparation", async function () {
-    await ui5.navigation.navigateToApplication("Shell-home", false);
-    const urlExpected = `${await util.browser.getBaseUrl()}#Shell-home`;
-    await common.assertion.expectUrlToBe(urlExpected);
-  });
-
-  it("Execution", async function () {
-    await ui5.navigation.navigateToApplicationWithQueryParams(intent, query, false);
-  });
-
-
-  it("Verification", async function () {
-    const urlExpected = `${await util.browser.getBaseUrl()}${query}#${intent}`;
-    await common.assertion.expectUrlToBe(urlExpected);
-
-    // if 'query' includes no "?", url will be interpreted as another (unsupported) mount
-    await expect(nonUi5.element.getById("parseUrl"))
-      .rejects.toThrow(/Element with id "parseUrl" not found/);
-  });
-});
-
 describe("navigation - navigateToApplicationWithQueryParams with empty param in url", function () {
   const intent = "PurchaseOrder-manage";
 

--- a/test/reuse/ui5/navigation/navigateToApplicationWithQueryParamsAndRetry.spec.js
+++ b/test/reuse/ui5/navigation/navigateToApplicationWithQueryParamsAndRetry.spec.js
@@ -20,31 +20,6 @@ describe("navigation - navigateToApplicationWithQueryParamsAndRetry with query p
   });
 });
 
-describe("navigation - navigateToApplicationWithQueryParamsAndRetry with wrong param in url", function () {
-  const query = "unknownParam=value"; // query without '?' mark
-  const intent = "PurchaseOrder-manage";
-
-  it("Preparation", async function () {
-    await ui5.navigation.navigateToApplication("Shell-home", false);
-    const urlExpected = `${await util.browser.getBaseUrl()}#Shell-home`;
-    await common.assertion.expectUrlToBe(urlExpected);
-  });
-
-  it("Execution", async function () {
-    await ui5.navigation.navigateToApplicationWithQueryParamsAndRetry(intent, query, false);
-  });
-
-
-  it("Verification", async function () {
-    const urlExpected = `${await util.browser.getBaseUrl()}${query}#${intent}`;
-    await common.assertion.expectUrlToBe(urlExpected);
-
-    // if 'query' includes no "?", url will be interpreted as another (unsupported) mount
-    await expect(nonUi5.element.getById("parseUrl"))
-      .rejects.toThrow(/Element with id "parseUrl" not found/);
-  });
-});
-
 describe("navigation - navigateToApplicationWithQueryParamsAndRetry with empty param in url", function () {
   const intent = "PurchaseOrder-manage";
 

--- a/test/reuse/ui5/navigation/test.navigation.static.conf.js
+++ b/test/reuse/ui5/navigation/test.navigation.static.conf.js
@@ -7,25 +7,23 @@ exports.config = merge(profile.config, {
   baseUrl: "http://localhost:34099/ui",
 
   services: [
-    ["static-server", {
-      port: 34099,
-      folders: [{
-        mount: "/ui",
-        path: path.resolve(__dirname, "./website/main.html")
-      }, ]
-    }]
+    [
+      "static-server",
+      {
+        port: 34099,
+        folders: [
+          {
+            mount: "/ui",
+            path: path.resolve(__dirname, "./website/main.html")
+          }
+        ]
+      }
+    ]
   ],
 
-  specs: [
-    // path.resolve(__dirname, "navigateToApplication.spec.js"),
-    path.resolve(__dirname, "navigateToApplicationAndRetry.spec.js"),
-    // path.resolve(__dirname, "navigateToApplicationWithQueryParams.spec.js"),
-    // path.resolve(__dirname, "navigateToApplicationWithQueryParamsAndRetry.spec.js")
-  ],
-
-  exclude: [],
+  specs: [path.resolve(__dirname, "navigateToApplication.spec.js"), path.resolve(__dirname, "navigateToApplicationAndRetry.spec.js"), path.resolve(__dirname, "navigateToApplicationWithQueryParams.spec.js"), path.resolve(__dirname, "navigateToApplicationWithQueryParamsAndRetry.spec.js")],
 
   mochaOpts: {
-    timeout: 2000000,
-  },
+    timeout: 2000000
+  }
 });

--- a/test/reuse/ui5/navigation/website/main.html
+++ b/test/reuse/ui5/navigation/website/main.html
@@ -22,29 +22,28 @@
 
 <body>
 
-<nav class="navbar navbar-light ">
-  <a class="navbar-brand" href="#">Ui5 navigation testing</a>
-</nav>
+  <nav class="navbar navbar-light ">
+    <a class="navbar-brand" href="#">Ui5 navigation testing</a>
+  </nav>
 
-<div class="container-fluid">
-  <div class="row content">
-    <div class="well">
-      <button type="button" id="parseUrl" onclick="parseUrl();"
-              class="btn btn-default">Parse URL</button>
-    </div>
-    <br>
-    <div class="col-sm-5">
-      <div class="row">
-        <div class="col-sm-5">
-          <div class="well">
-            <label> Your URL is: </label>
-            <p><span id="navigationUrl">not parsed yet</span></p>
+  <div class="container-fluid">
+    <div class="row content">
+      <div class="well">
+        <button type="button" id="parseUrl" onclick="parseUrl();" class="btn btn-default">Parse URL</button>
+      </div>
+      <br>
+      <div class="col-sm-5">
+        <div class="row">
+          <div class="col-sm-5">
+            <div class="well">
+              <label> Your URL is: </label>
+              <p><span id="navigationUrl">not parsed yet</span></p>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 </body>
 
 </html>

--- a/test/reuse/ui5/navigationBar/clickBack.spec.js
+++ b/test/reuse/ui5/navigationBar/clickBack.spec.js
@@ -2,12 +2,12 @@
 
 describe("navigationBar - clickBack", async function () {
   it("Preparation", async function () {
-    await common.navigation.navigateToUrl("https://sapui5.hana.ondemand.com/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home");
+    await common.navigation.navigateToUrl(browser.config.baseUrl);
     const selector = {
-      elementProperties: {
-        viewName: "sap.ushell.components.tiles.cdm.applauncher.StaticTile",
-        metadata: "sap.m.GenericTile",
-        bindingContextPath: "/pages/0/sections/0/visualizations/0"
+      "elementProperties": {
+        "viewName": "sap.ushell.components.homepage.DashboardContent",
+        "metadata": "sap.m.GenericTile",
+        "bindingContextPath": "/groups/1/tiles/1/content/0"
       }
     };
     await ui5.userInteraction.click(selector);
@@ -24,7 +24,7 @@ describe("navigationBar - clickBack", async function () {
 
 describe("navigationBar - clickBack - error case", function () {
   it("Preparation", async function () {
-    await common.navigation.navigateToUrl("https://sapui5.hana.ondemand.com/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home");
+    await common.navigation.navigateToUrl(browser.config.baseUrl);
   });
 
   it("Execution & Verification", async function () {

--- a/test/reuse/ui5/navigationBar/clickUserIcon.spec.js
+++ b/test/reuse/ui5/navigationBar/clickUserIcon.spec.js
@@ -3,7 +3,7 @@
 describe("navigationBar - clickUserIcon", async function () {
 
   it("Preparation", async function () {
-    await common.navigation.navigateToUrl("https://sapui5.hana.ondemand.com/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home");
+    await common.navigation.navigateToUrl(browser.config.baseUrl);
   });
 
   it("Execution", async function () {

--- a/test/reuse/ui5/navigationBar/expectPageTitle.spec.js
+++ b/test/reuse/ui5/navigationBar/expectPageTitle.spec.js
@@ -2,7 +2,7 @@
 
 describe("navigationBar - expectPageTitle", function () {
   it("Preparation", async function () {
-    await common.navigation.navigateToUrl("https://sapui5.hana.ondemand.com/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home");
+    await common.navigation.navigateToUrl(browser.config.baseUrl);
   });
 
   it("Execution & Verification", async function () {

--- a/test/reuse/ui5/navigationBar/expectShellHeader.spec.js
+++ b/test/reuse/ui5/navigationBar/expectShellHeader.spec.js
@@ -2,7 +2,7 @@
 
 describe("navigationBar - expectShellHeader", function () {
   it("Preparation", async function () {
-    await common.navigation.navigateToUrl("https://sapui5.hana.ondemand.com/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home");
+    await common.navigation.navigateToUrl(browser.config.baseUrl);
   });
 
   it("Execution & Verification", async function () {

--- a/test/reuse/ui5/navigationBar/test.navigationBar.conf.js
+++ b/test/reuse/ui5/navigationBar/test.navigationBar.conf.js
@@ -6,7 +6,7 @@ exports.config = merge(profile.config, {
   maxInstances: 4,
   specFileRetries: 2,
 
-  baseUrl: "https://sapui5.hana.ondemand.com/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home",
+  baseUrl: "https://sapui5.hana.ondemand.com/1.96.27/test-resources/sap/ui/demoapps/demokit/rta/fiori-elements/test/index.html#Shell-home",
 
   specs: [
     path.resolve(__dirname, "clickBack.spec.js"),


### PR DESCRIPTION
This PR refactors the `navigateToApplication` function to enhance the robustness and transparency of query parameter handling. Previously, there was an issue where language parameters (`?lang=EN`) were not functioning correctly in LAT environments due to the presence of multiple ? characters in the URL.

With this change, possible params from both, baseUrl and intent are now extracted and concatenated with the optional popup skipping params afterwards.