### PR TITLE
fix the order of intent query params in navigation

### DIFF
--- a/src/reuse/modules/ui5/navigation.ts
+++ b/src/reuse/modules/ui5/navigation.ts
@@ -43,9 +43,9 @@ export class Navigation {
     let queryParams: Array<QueryParam> = [];
 
     // Check if intent has query params and extract them from the intent
-    queryParams = queryParams.concat(this._extractQueryParams(intent));
+    const intentQueryParams = this._extractQueryParams(intent);
 
-    // Check if baseUrl has query params and extract them from the baseUrl
+    // Check if baseUrl has query params, extract them from the baseUrl and merge them with the existing params
     queryParams = queryParams.concat(this._extractQueryParams(browser.config.baseUrl));
 
     // Add prevent popup url params if not already present
@@ -53,10 +53,16 @@ export class Navigation {
       queryParams = queryParams.concat(this._getPreventPopupParams(queryParams));
     }
 
-    // Construct the url with the intent and query params
+    // Construct the url params
     let constructedParams = this._constructUrlParams(queryParams);
     if (constructedParams !== "") constructedParams = `?${constructedParams}`;
-    const urlWithParams = `${baseUrlNormalized}${constructedParams}#${intentNormalized}`;
+
+    // Construct the intent params
+    let constructedIntentParams = this._constructUrlParams(intentQueryParams);
+    if (constructedIntentParams !== "") constructedIntentParams = `?${constructedIntentParams}`;
+
+    // Construct the final url
+    const urlWithParams = `${baseUrlNormalized}${constructedParams}#${intentNormalized}${constructedIntentParams}`;
     vl.log(`Url with params: ${urlWithParams}`);
 
     try {

--- a/test/reuse/ui5/navigation/navigateToApplication.spec.js
+++ b/test/reuse/ui5/navigation/navigateToApplication.spec.js
@@ -10,7 +10,8 @@
 
 const BASE_URL = `http://localhost:34099/ui`;
 const INTENT = "Shell-home";
-const DUMMY_QUERY_PARAM = "dummyQueryParam=dummyValue";
+const DUMMY_QUERY_PARAM_1 = "dummyQueryParam1=dummyValue1";
+const DUMMY_QUERY_PARAM_2 = "dummyQueryParam2=dummyValue2";
 const PREVENT_POPUP_QUERY_PARAMS = "help-readCatalog=false&help-stateUACP=PRODUCTION";
 
 describe("navigation - navigateToApplication - preventPopups=false", function () {
@@ -60,7 +61,7 @@ describe("navigation - navigateToApplication - baseUrl with closePopup query par
 
 describe("navigation - navigateToApplication - baseUrl with dummy query parameters", function () {
   it("Preparation", async function () {
-    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM}`;
+    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM_1}`;
   });
 
   it("Execution", async function () {
@@ -68,29 +69,44 @@ describe("navigation - navigateToApplication - baseUrl with dummy query paramete
   });
 
   it("Verification", async function () {
-    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM}#Shell-home`;
+    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM_1}#Shell-home`;
     await common.assertion.expectUrlToBe(urlExp);
   });
 });
 
-describe("navigation - navigateToApplication - intent with dummy query parameters", function () {
+describe("navigation - navigateToApplication - intent and baseUrl with query parameters", function () {
+  it("Preparation", async function () {
+    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM_1}`;
+  });
+
+  it("Execution", async function () {
+    await ui5.navigation.navigateToApplication(`${INTENT}?${DUMMY_QUERY_PARAM_2}`, false);
+  });
+
+  it("Verification", async function () {
+    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM_1}#Shell-home?${DUMMY_QUERY_PARAM_2}`;
+    await common.assertion.expectUrlToBe(urlExp);
+  });
+});
+
+describe("navigation - navigateToApplication - intent with multiple query parameters", function () {
   it("Preparation", async function () {
     browser.config.baseUrl = BASE_URL;
   });
 
   it("Execution", async function () {
-    await ui5.navigation.navigateToApplication(`${INTENT}?${DUMMY_QUERY_PARAM}`, false);
+    await ui5.navigation.navigateToApplication(`${INTENT}?${DUMMY_QUERY_PARAM_1}&${DUMMY_QUERY_PARAM_2}`, false);
   });
 
   it("Verification", async function () {
-    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM}#Shell-home`;
+    const urlExp = `${BASE_URL}#Shell-home?${DUMMY_QUERY_PARAM_1}&${DUMMY_QUERY_PARAM_2}`;
     await common.assertion.expectUrlToBe(urlExp);
   });
 });
 
 describe("navigation - navigateToApplication - baseUrl with multiple query parameters", function () {
   it("Preparation", async function () {
-    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM}&${PREVENT_POPUP_QUERY_PARAMS}`;
+    browser.config.baseUrl = `${BASE_URL}?${DUMMY_QUERY_PARAM_1}&${PREVENT_POPUP_QUERY_PARAMS}`;
   });
 
   it("Execution", async function () {
@@ -98,7 +114,7 @@ describe("navigation - navigateToApplication - baseUrl with multiple query param
   });
 
   it("Verification", async function () {
-    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM}&${PREVENT_POPUP_QUERY_PARAMS}#Shell-home`;
+    const urlExp = `${BASE_URL}?${DUMMY_QUERY_PARAM_1}&${PREVENT_POPUP_QUERY_PARAMS}#Shell-home`;
     await common.assertion.expectUrlToBe(urlExp);
   });
 });


### PR DESCRIPTION
Seems like the order is critical in the url params at UI5 apps. Therefore I have adjusted the code to keep the order of the params of the intent. 