### PR TITLE
Adding few more lib methods for Mobile

### DIFF
--- a/src/reuse/helper/elementResolving.ts
+++ b/src/reuse/helper/elementResolving.ts
@@ -14,7 +14,7 @@ export async function resolveCssSelectorOrElement(elementOrSelector: Element | s
 
 export async function resolveMobileSelectorOrElement(elementOrSelector: Element | string): Promise<Element> {
   if (!elementOrSelector) {
-    throw new Error("Please provide an element or a CSS selector as first argument.");
+    throw new Error("Please provide an element or a selector as first argument.");
   }
 
   if (typeof elementOrSelector === "string") {

--- a/src/reuse/helper/elementResolving.ts
+++ b/src/reuse/helper/elementResolving.ts
@@ -11,3 +11,15 @@ export async function resolveCssSelectorOrElement(elementOrSelector: Element | s
     return elementOrSelector;
   }
 }
+
+export async function resolveMobileSelectorOrElement(elementOrSelector: Element | string): Promise<Element> {
+  if (!elementOrSelector) {
+    throw new Error("Please provide an element or a CSS selector as first argument.");
+  }
+
+  if (typeof elementOrSelector === "string") {
+    return await $(elementOrSelector);
+  } else {
+    return elementOrSelector;
+  }
+}

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -118,7 +118,7 @@ export class Device {
 
     try {
       let target = this.getTargetContextIfAvailable(targetContext, timeout);
-      if (typeof target === "string") {
+      if (target) {
         await browser.switchContext(target);
         vl.log(`Switched to ${target} context successfully...`);
         return true;

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -261,7 +261,7 @@ export class Device {
   /**
    * @function getCurrentOrientation
    * @memberof mobile.device
-   * @description Switches the device orientation to portrait mode.
+   * @description Returns the device orientation.
    * @returns {Promise<string>} Resolves when the orientation is successfully switched.
    * @example
    * await mobile.device.getCurrentOrientation();

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -307,8 +307,15 @@ export class Device {
    * @param {number} keyCode - Key code for Android (optional).
    * @param {number} [timeout=5000] - Timeout in milliseconds for retrying to hide the keyboard.
    * @returns {Promise<void>}
+   * @example
+   * await mobile.device.hideKeyboard();
+   * await mobile.device.hideKeyboard('tapOutside');
+   * await mobile.device.hideKeyboard('swipeDown');
+   * //Android only, Sends a specific key code, like 66 for "Enter."
+   * await mobile.device.hideKeyboard('pressKey', undefined, 66);
+   * await mobile.device.hideKeyboard('pressKey', 'Done');
    */
-  async hideKeyboard(strategy: hideKeyboardStrategy, key?: string, keyCode?: number, timeout: number = 5000): Promise<void> {
+  async hideKeyboard(strategy?: hideKeyboardStrategy, key?: string, keyCode?: number, timeout: number = 5000): Promise<void> {
     const vl = this.vlf.initLog(this.hideKeyboard);
 
     const startTime = Date.now();
@@ -327,9 +334,9 @@ export class Device {
         vl.log("Keyboard hidden successfully.");
         return; // Exit if the keyboard is successfully hidden
       } catch (error) {
-        this.ErrorHandler.logException(error, `Error: Failed to hide the keyboard. Retrying...`, true);
         // Wait briefly before retrying
         await new Promise((resolve) => setTimeout(resolve, 500));
+        this.ErrorHandler.logException(error, `Error: Failed to hide the keyboard, Retrying...`, true);
       }
     }
     vl.log(`Failed to hide the keyboard within the timeout of ${timeout}ms.`);
@@ -339,7 +346,9 @@ export class Device {
    * @function isKeyboardVisible
    * @memberof mobile.device
    * @description Checks if the keyboard is visible or not on the mobile device.
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} Returns 'true' if the keyboard is visible on the mobile view.
+   * @example
+   * await mobile.device.isKeyboardVisible();
    */
   async isKeyboardVisible(): Promise<boolean> {
     const vl = this.vlf.initLog(this.isKeyboardVisible);
@@ -368,6 +377,18 @@ export class Device {
       this.ErrorHandler.logException(error, `Error: Failed to get the is keyboard visible`, true);
     }
     return isKeyboardVisible;
+  }
+
+  /**
+   * @function isPlatformSupported
+   * @memberof mobile.device
+   * @description Determine if the current platform is supported, if the current device platform is either Android or iOS.
+   * @returns {Promise<boolean>} If neither Android nor iOS is detected (e.g., Windows, Linux, or web), the condition evaluates to false
+   * @example
+   * await mobile.device.isPlatformSupported();
+   */
+  async isPlatformSupported(): Promise<boolean> {
+    return (await util.browser.isAndroid()) || (await util.browser.isIos());
   }
 }
 export default new Device();

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -321,7 +321,7 @@ export class Device {
   }
 
   /**
-   * @function hideKeyboard
+   * @function isKeyboardVisible
    * @memberof mobile.device
    * @description Checks if the keyboard is visible or not on the mobile device.
    * @returns {Promise<boolean>}

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -132,6 +132,9 @@ export class Device {
   }
 
   /**
+   * @function getTargetContextIfAvailable
+   * @memberof mobile.device
+   * @description
    * Returns the specified target context if available within a given timeout.
    *
    * This method retrieves the list of available contexts and determines if a context
@@ -145,8 +148,8 @@ export class Device {
    * @returns {Promise<string | null>} - The name of the target context if found, or `null` if
    *   the context is not available within the timeout.
    * @example
-   * const context = await getTargetContextAvailable("WEBVIEW", 10000);
-   * const context = await getTargetContextAvailable("NATIVE_APP", 10000);
+   * const context = await getTargetContextIfAvailable("WEBVIEW", 10000);
+   * const context = await getTargetContextIfAvailable("NATIVE_APP", 10000);
    */
   async getTargetContextIfAvailable(targetContext: string = "WEBVIEW", timeout: number = 5000): Promise<string | null> {
     const vl = this.vlf.initLog(this.getTargetContextIfAvailable);

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -117,11 +117,12 @@ export class Device {
     const vl = this.vlf.initLog(this.switchToContext);
 
     try {
-      const isWebContextAvailable = await browser.waitUntil(
+      let availableContexts: string[] = [];
+      const isContextAvailable = await browser.waitUntil(
         async () => {
           // Get all available contexts
-          const contexts: string[] = await browser.getContexts();
-          return contexts.some((context) => context.includes(targetContext));
+          availableContexts = await browser.getContexts();
+          return availableContexts.some((context) => context.includes(targetContext));
         },
         {
           timeout,
@@ -129,15 +130,13 @@ export class Device {
         }
       );
 
-      if (isWebContextAvailable) {
-        const contexts: string[] = await browser.getContexts();
+      if (isContextAvailable) {
         // Find and switch to the target context
-        for (const context of contexts) {
-          if (context.includes(targetContext)) {
-            await browser.switchContext(context);
-            vl.log(`Switched to ${context} context successfully...`);
-            return true;
-          }
+        const target = availableContexts.find((context) => context.includes(targetContext));
+        if (target) {
+          await browser.switchContext(target);
+          vl.log(`Switched to ${target} context successfully...`);
+          return true;
         }
       } else {
         vl.log(`Context ${targetContext} is not available.`);

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -238,7 +238,7 @@ export class Device {
    * @example
    * await mobile.device.switchToPortrait();
    */
-  async switchToPortrait(): Promise<void> {
+  async switchToPortraitOrientation(): Promise<void> {
     const vl = this.vlf.initLog(this.switchToPortrait);
 
     try {

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -288,7 +288,7 @@ export class Device {
    * @param {string} strategy - Strategy to use for hiding the keyboard ('pressKey', 'tapOutside', 'swipeDown').
    * @param {string} key - Key to press if using the 'pressKey' strategy (e.g., 'Done', 'Enter').
    * @param {number} keyCode - Key code for Android (optional).
-   * @param {number} timeout - Timeout in milliseconds for retrying to hide the keyboard (default: 5000ms).
+   * @param {number} [timeout=5000] - Timeout in milliseconds for retrying to hide the keyboard.
    * @returns {Promise<void>}
    */
   async hideKeyboard(strategy: hideKeyboardStrategy, key?: string, keyCode?: number, timeout: number = 5000): Promise<void> {

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -68,10 +68,10 @@ export class Device {
         isAppInstalledInDevice = browser.isAppInstalled(appPackageOrBundleId);
         vl.log(`${await this.executionPlatform()} app installed successfully.`);
       } else {
-        console.error(`Unsupported platform ${await this.executionPlatform()} while checking the is app installed or not`);
+        vl.log(`Unsupported platform while checking the is app installed or not`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: Failed at is app installed", true);
+      this.ErrorHandler.logException(error, "Error: Could not determine if app is installed, The provided package name is invalid.", true);
     }
     return isAppInstalledInDevice;
   }
@@ -95,10 +95,10 @@ export class Device {
         await browser.installApp(appPath);
         vl.log(`${await this.executionPlatform()} app installed successfully.`);
       } else {
-        console.error(`Unsupported platform ${await this.executionPlatform()} while installing app`);
+        vl.log(`Unsupported platform ${await this.executionPlatform()} while installing app`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed installing the app: ${await this.executionPlatform()}`, true);
+      this.ErrorHandler.logException(error, `Error: Unable to install app. The provided app path ${appPath} does not exist`, true);
     }
   }
 
@@ -117,7 +117,7 @@ export class Device {
     const vl = this.vlf.initLog(this.switchToContext);
 
     try {
-      let target = this.isTargetContextAvailable(targetContext, timeout);
+      let target = this.getTargetContextAvailable(targetContext, timeout);
       if (typeof target === "string") {
         await browser.switchContext(target);
         vl.log(`Switched to ${target} context successfully...`);
@@ -126,7 +126,7 @@ export class Device {
         vl.log(`Switched to ${target} context not successful, it may be null`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to switch context`, true);
+      this.ErrorHandler.logException(error, `Error: No contexts available, Could not switch to ${targetContext} context 'INVALID_CONTEXT'. `, true);
     }
     return false;
   }
@@ -145,11 +145,11 @@ export class Device {
    * @returns {Promise<string | null>} - The name of the target context if found, or `null` if
    *   the context is not available within the timeout.
    * @example
-   * const context = await isTargetContextAvailable("WEBVIEW", 10000);
-   * const context = await isTargetContextAvailable("NATIVE_APP", 10000);
+   * const context = await getTargetContextAvailable("WEBVIEW", 10000);
+   * const context = await getTargetContextAvailable("NATIVE_APP", 10000);
    */
-  async isTargetContextAvailable(targetContext: string = "WEBVIEW", timeout: number = 5000): Promise<string | null> {
-    const vl = this.vlf.initLog(this.isTargetContextAvailable);
+  async getTargetContextAvailable(targetContext: string = "WEBVIEW", timeout: number = 5000): Promise<string | null> {
+    const vl = this.vlf.initLog(this.getTargetContextAvailable);
 
     try {
       let availableContexts: string[] = [];
@@ -173,7 +173,7 @@ export class Device {
         vl.log(`Target Context ${targetContext} is not available.`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to check is target context available`, true);
+      this.ErrorHandler.logException(error, `Error: No contexts available, Failed to check is target ${targetContext} context available`, true);
     }
     return null;
   }
@@ -193,7 +193,7 @@ export class Device {
       await browser.closeApp();
       vl.log("The application has been closed successfully.");
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to close the application`, true);
+      this.ErrorHandler.logException(error, `Error: Unable to close app, the app is not currently running`, true);
     }
   }
 
@@ -225,7 +225,7 @@ export class Device {
         vl.log(`Unsupported platform while query app state: ${await this.executionPlatform()}`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to query app state for ${appPackageOrBundleId}:`, true);
+      this.ErrorHandler.logException(error, `Error: Unable to query app state, the package name ${appPackageOrBundleId} is invalid or does not exist.`, true);
     }
     return appState;
   }
@@ -252,7 +252,7 @@ export class Device {
         vl.log(`Unsupported platform while launching the app: ${await this.executionPlatform()}`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to launchApp`, true);
+      this.ErrorHandler.logException(error, `Error: Unable to launch the app, the package name ${appPackageOrBundleId} is invalid or does not exist.`, true);
     }
   }
 
@@ -278,7 +278,7 @@ export class Device {
       await browser.setOrientation(ORIENTATION.LANDSCAPE);
       vl.log("Device orientation successfully switched to landscape.");
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to switch device orientation to landscape`, true);
+      this.ErrorHandler.logException(error, `Error: Could not change device orientation, Invalid argument: The orientation must be 'LANDSCAPE'.`, true);
     }
   }
 
@@ -304,7 +304,7 @@ export class Device {
       await browser.setOrientation(ORIENTATION.PORTRAIT);
       vl.log("Device orientation successfully switched to portrait.");
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to switch device orientation to portrait`, true);
+      this.ErrorHandler.logException(error, `Error: Could not change device orientation, Invalid argument: The orientation must be 'PORTRAIT`, true);
     }
   }
 
@@ -312,7 +312,7 @@ export class Device {
    * @function getCurrentOrientation
    * @memberof mobile.device
    * @description Returns the device current orientation (PORTRAIT or LANDSCAPE)
-   * @returns {Promise<Orientation>} Get the current device orientation.
+   * @returns {Promise<Orientation>} The current device orientation.
    * @example
    * await mobile.device.getCurrentOrientation();
    */
@@ -324,7 +324,7 @@ export class Device {
       orientation = await browser.getOrientation();
       vl.log(`Current device orientation: ${orientation}`);
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to get the current device orientation`, true);
+      this.ErrorHandler.logException(error, `Error: Could not get the current device orientation`, true);
     }
     return orientation;
   }

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -65,7 +65,7 @@ export class Device {
         console.error(`Unsupported platform ${platform.toLowerCase().trim()} while installing app`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Failed to installing the app: ${platform.toLowerCase().trim()}`, true);
+      this.ErrorHandler.logException(error, `Error: Failed installing the app: ${platform.toLowerCase().trim()}`, true);
     }
   }
 

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -210,7 +210,7 @@ export class Device {
    * @example
    * await mobile.device.switchToLandscape();
    */
-  async switchToLandscape(): Promise<void> {
+  async switchToLandscapeOrientation(): Promise<void> {
     const vl = this.vlf.initLog(this.switchToLandscape);
 
     try {

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -74,7 +74,7 @@ export class Device {
    * @memberof mobile.device
    * @description Switch to the specified( WEBVIEW | NATIVE_APP ) context if available.
    * @param {string} [targetContext='WEBVIEW'] The name of the target context.
-   * @param {number} timeout Maximum time to wait for the web context to appear (default: 5000ms).
+   * @param {number} [timeout=5000] Maximum time to wait for the web context to appear, milliseconds.
    * @returns {Promise<boolean>} Returns 'true' if the context is successfully switched, otherwise 'false'.
    * @example
    * await mobile.device.switchToContext();

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -117,7 +117,7 @@ export class Device {
     const vl = this.vlf.initLog(this.switchToContext);
 
     try {
-      let target = this.getTargetContextAvailable(targetContext, timeout);
+      let target = this.getTargetContextIfAvailable(targetContext, timeout);
       if (typeof target === "string") {
         await browser.switchContext(target);
         vl.log(`Switched to ${target} context successfully...`);
@@ -132,7 +132,7 @@ export class Device {
   }
 
   /**
-   * Checks if the specified target context is available within a given timeout.
+   * Returns the specified target context if available within a given timeout.
    *
    * This method retrieves the list of available contexts and determines if a context
    * that matches the `targetContext` string is present. If the target context is found,
@@ -148,8 +148,8 @@ export class Device {
    * const context = await getTargetContextAvailable("WEBVIEW", 10000);
    * const context = await getTargetContextAvailable("NATIVE_APP", 10000);
    */
-  async getTargetContextAvailable(targetContext: string = "WEBVIEW", timeout: number = 5000): Promise<string | null> {
-    const vl = this.vlf.initLog(this.getTargetContextAvailable);
+  async getTargetContextIfAvailable(targetContext: string = "WEBVIEW", timeout: number = 5000): Promise<string | null> {
+    const vl = this.vlf.initLog(this.getTargetContextIfAvailable);
 
     try {
       let availableContexts: string[] = [];

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -73,7 +73,7 @@ export class Device {
    * @function switchToContext
    * @memberof mobile.device
    * @description Switch to the specified( WEBVIEW | NATIVE_APP ) context if available.
-   * @param {string} targetContext The name of the target context (default: 'WEBVIEW').
+   * @param {string} [targetContext='WEBVIEW'] The name of the target context.
    * @param {number} timeout Maximum time to wait for the web context to appear (default: 5000ms).
    * @returns {Promise<boolean>} Returns 'true' if the context is successfully switched, otherwise 'false'.
    * @example

--- a/src/reuse/modules/mobile/device.ts
+++ b/src/reuse/modules/mobile/device.ts
@@ -1,6 +1,10 @@
 "use strict";
+// Imports
 import { VerboseLoggerFactory } from "../../helper/verboseLogger";
 import ErrorHandler from "../../helper/errorHandler";
+
+// Types
+type hideKeyboardStrategy = "pressKey" | "tapOutside" | "swipeDown" | "";
 
 /**
  * @class device
@@ -14,19 +18,28 @@ export class Device {
    * @function isAppInstalled
    * @memberof mobile.device
    * @description Check wether given package/bundle app is installed or not in the device.
-   * @param {string} packageIdOrBundleId - Android package Id, or iOS bundle Id.
-   * @returns {boolean} Returns true if specified app package/bundled installed in the device, or false.
-   * @example await mobile.device.isAppInstalled("com.google.android.apps.maps");
+   * @param {string} appPackageOrBundleId - Android package Id, or iOS bundle Id.
+   * @returns {boolean} Returns 'true' if specified app package/bundled installed in the device, or 'false'.
+   * @example
+   * await mobile.device.isAppInstalled("com.google.android.apps.maps");
+   * await mobile.device.isAppInstalled("com.apple.AppStore")
    */
-  async isAppInstalled(packageIdOrBundleId: string): Promise<boolean> {
+  async isAppInstalled(appPackageOrBundleId: string): Promise<boolean> {
     const vl = this.vlf.initLog(this.isAppInstalled);
+
+    let isAppInstalledInDevice: boolean = false;
+    const platform: string = await browser.capabilities.platformName;
     try {
-      const isAppInstalledInDevice: boolean = browser.isAppInstalled(packageIdOrBundleId);
-      vl.log(`Given app package/bundle id ${packageIdOrBundleId} installed on the device is ${isAppInstalledInDevice.toString()}`);
-      return isAppInstalledInDevice;
+      if (["android", "ios"].includes(platform.toLowerCase().trim())) {
+        isAppInstalledInDevice = browser.isAppInstalled(appPackageOrBundleId);
+        vl.log(`${platform.toLowerCase()} app installed successfully.`);
+      } else {
+        console.error(`Unsupported platform ${platform.toLowerCase().trim()} while checking the is app installed or not`);
+      }
     } catch (error) {
-      return this.ErrorHandler.logException(error, "Error: During isAppInstalled", true);
+      this.ErrorHandler.logException(error, "Error: Failed at is app installed", true);
     }
+    return isAppInstalledInDevice;
   }
 
   /**
@@ -34,22 +47,313 @@ export class Device {
    * @memberof mobile.device
    * @description Install the appropriate app based on the platform the test is being executed on.
    * @param {string} appPath - Path of the app(.apk, .ipa)
+   * @returns {Promise<void>}
    * @example
    * await mobile.device.installApp("/path/to/your/app.apk");
    * await mobile.device.installApp("/path/to/your/app.ipa");
    */
   async installApp(appPath: string): Promise<void> {
     const vl = this.vlf.initLog(this.installApp);
-    const platform: String = await browser.capabilities.platformName;
+
+    const platform: string = await browser.capabilities.platformName;
     try {
       vl.log(`Installing ${platform.toLowerCase()} app...`);
       if (["android", "ios"].includes(platform.toLowerCase().trim())) {
         await browser.installApp(appPath);
         vl.log(`${platform.toLowerCase()} app installed successfully.`);
+      } else {
+        console.error(`Unsupported platform ${platform.toLowerCase().trim()} while installing app`);
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, `Error: Unsupported platform while installing the app: ${platform.toLowerCase().trim()}`, true);
+      this.ErrorHandler.logException(error, `Error: Failed to installing the app: ${platform.toLowerCase().trim()}`, true);
     }
+  }
+
+  /**
+   * @function switchToContext
+   * @memberof mobile.device
+   * @description Switch to the specified( WEBVIEW | NATIVE_APP ) context if available.
+   * @param {string} targetContext The name of the target context (default: 'WEBVIEW').
+   * @param {number} timeout Maximum time to wait for the web context to appear (default: 5000ms).
+   * @returns {Promise<boolean>} Returns 'true' if the context is successfully switched, otherwise 'false'.
+   * @example
+   * await mobile.device.switchToContext();
+   * await mobile.device.switchToContext("NATIVE_APP", 1000);
+   */
+  async switchToContext(targetContext: string = "WEBVIEW", timeout: number = 5000): Promise<boolean> {
+    const vl = this.vlf.initLog(this.switchToContext);
+
+    try {
+      const isWebContextAvailable = await browser.waitUntil(
+        async () => {
+          // Get all available contexts
+          const contexts: string[] = await browser.getContexts();
+          return contexts.some((context) => context.includes(targetContext));
+        },
+        {
+          timeout,
+          timeoutMsg: `Context "${targetContext}" not found within ${timeout}ms`
+        }
+      );
+
+      if (isWebContextAvailable) {
+        const contexts: string[] = await browser.getContexts();
+        // Find and switch to the target context
+        for (const context of contexts) {
+          if (context.includes(targetContext)) {
+            await browser.switchContext(context);
+            vl.log(`Switched to ${context} context successfully...`);
+            console.log(`Switched to ${context} context successfully...`);
+            return true;
+          }
+        }
+      } else {
+        vl.log(`Context ${targetContext} is not available.`);
+      }
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to switch context`, true);
+    }
+    return false;
+  }
+
+  /**
+   * @function closeApplication
+   * @memberof mobile.device
+   * @description Close the currently active mobile application.
+   * @returns {Promise<void>}
+   * @example
+   * await mobile.device.closeApplication();
+   */
+  async closeApplication(): Promise<void> {
+    const vl = this.vlf.initLog(this.closeApplication);
+
+    try {
+      await browser.closeApp();
+      vl.log("The application has been closed successfully.");
+      console.log("The application has been closed successfully.");
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to close the application`, true);
+      console.error("Failed to close the application:", error);
+    }
+  }
+
+  /**
+   * @function queryAppState
+   * @memberof mobile.device
+   * @description Queries the state of the application (e.g., running, background, not installed) on the mobile device(Android or iOS).
+   * @param {string} appPackageOrBundleId - Package name (Android) or bundle ID (iOS) of the application.
+   * @returns {Promise<number>} - The app state:
+   *  0 - Not running,
+   *  1 - Not installed,
+   *  2 - Running in the background (not suspended),
+   *  3 - Running in the background (suspended),
+   *  4 - Running in the foreground.
+   * @example
+   * await mobile.device.queryAppState("com.google.android.apps.maps");
+   * await mobile.device.queryAppState("com.apple.AppStore");
+   */
+  async queryAppState(appPackageOrBundleId: string): Promise<number> {
+    const vl = this.vlf.initLog(this.queryAppState);
+
+    const platform: string = await browser.capabilities.platformName;
+    let appState: number = -1;
+    try {
+      vl.log(`Querying the app ${platform.toLowerCase()} state...`);
+      if (["android", "ios"].includes(platform.toLowerCase().trim())) {
+        appState = await browser.queryAppState(appPackageOrBundleId);
+        vl.log(`Application state for ${appPackageOrBundleId} : ${appState}`);
+        console.log(`Application state for ${appPackageOrBundleId} : ${appState}`);
+      } else {
+        console.error(`Unsupported platform while query app state: ${platform.toLowerCase().trim()}`);
+      }
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to query app state for ${appPackageOrBundleId}:`, true);
+      console.error(`Failed to query app state for ${appPackageOrBundleId}:`, error);
+    }
+    return appState;
+  }
+
+  /**
+   * @function launchApp
+   * @memberof mobile.device
+   * @description Launches the app for both iOS and Android with a parameterized app identifier.
+   * @param {string} appPackageOrBundleId - The Android package name or iOS bundle ID of the application.
+   * @returns {Promise<void>} Resolves when the app is successfully launched.
+   * @example
+   * await mobile.device.launchApp("com.google.android.apps.maps");
+   * await mobile.device.launchApp("com.apple.AppStore");
+   */
+  async launchApp(appPackageOrBundleId: string): Promise<void> {
+    const vl = this.vlf.initLog(this.launchApp);
+
+    const platform: string = await browser.capabilities.platformName;
+    try {
+      vl.log(`Launching ${platform.toLowerCase()} app...`);
+      if (["android", "ios"].includes(platform.toLowerCase().trim())) {
+        await browser.activateApp(appPackageOrBundleId);
+        console.log(`${platform.toLowerCase()} App launched successfully with given ${appPackageOrBundleId} Package/bundle ID`);
+        vl.log(`${platform.toLowerCase()} App launched successfully with given ${appPackageOrBundleId} Package/bundle ID`);
+      } else {
+        console.error(`Unsupported platform while launching the app: ${platform.toLowerCase().trim()}`);
+      }
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to launchApp`, true);
+      console.error("Error: Failed to launchApp", error);
+    }
+  }
+
+  /**
+   * @function switchToLandscape
+   * @memberof mobile.device
+   * @description Switches the device orientation to landscape mode.
+   * @returns {Promise<void>} Resolves when the orientation is successfully switched.
+   * @example
+   * await mobile.device.switchToLandscape();
+   */
+  async switchToLandscape(): Promise<void> {
+    const vl = this.vlf.initLog(this.switchToLandscape);
+
+    try {
+      const currentOrientation = await browser.getOrientation();
+      if (currentOrientation === "LANDSCAPE") {
+        vl.log("Device is already in landscape mode.");
+        console.log("Device is already in landscape mode.");
+        return;
+      }
+
+      console.log("Switching device orientation to landscape...");
+      await browser.setOrientation("LANDSCAPE");
+      console.log("Device orientation successfully switched to landscape.");
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to switch device orientation to landscape`, true);
+      console.error("Failed to switch device orientation to landscape:", error);
+    }
+  }
+
+  /**
+   * @function switchToPortrait
+   * @memberof mobile.device
+   * @description Switches the device orientation to portrait mode.
+   * @returns {Promise<void>} Resolves when the orientation is successfully switched.
+   * @example
+   * await mobile.device.switchToPortrait();
+   */
+  async switchToPortrait(): Promise<void> {
+    const vl = this.vlf.initLog(this.switchToPortrait);
+
+    try {
+      const currentOrientation = await browser.getOrientation();
+      if (currentOrientation === "PORTRAIT") {
+        vl.log("Device is already in portrait mode.");
+        console.log("Device is already in portrait mode.");
+        return;
+      }
+
+      console.log("Switching device orientation to portrait...");
+      await browser.setOrientation("PORTRAIT");
+      console.log("Device orientation successfully switched to portrait.");
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to switch device orientation to portrait`, true);
+      console.error("Failed to switch device orientation to portrait:", error);
+    }
+  }
+
+  /**
+   * @function getCurrentOrientation
+   * @memberof mobile.device
+   * @description Switches the device orientation to portrait mode.
+   * @returns {Promise<string>} Resolves when the orientation is successfully switched.
+   * @example
+   * await mobile.device.getCurrentOrientation();
+   */
+  async getCurrentOrientation(): Promise<string> {
+    const vl = this.vlf.initLog(this.getCurrentOrientation);
+
+    let orientation = "UNKNOWN"; // Default value
+    try {
+      orientation = await browser.getOrientation();
+      vl.log(`Current device orientation: ${orientation}`);
+      console.log(`Current device orientation: ${orientation}`);
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to get the current device orientation`, true);
+      console.error("Failed to get the current device orientation", error);
+    }
+    return orientation;
+  }
+
+  /**
+   * @function hideKeyboard
+   * @memberof mobile.device
+   * @description Hides the keyboard on both Android and iOS using specific strategies with timeout.
+   * @param {string} strategy - Strategy to use for hiding the keyboard ('pressKey', 'tapOutside', 'swipeDown').
+   * @param {string} key - Key to press if using the 'pressKey' strategy (e.g., 'Done', 'Enter').
+   * @param {number} keyCode - Key code for Android (optional).
+   * @param {number} timeout - Timeout in milliseconds for retrying to hide the keyboard (default: 5000ms).
+   * @returns {Promise<void>}
+   */
+  async hideKeyboard(strategy: hideKeyboardStrategy, key?: string, keyCode?: number, timeout: number = 5000): Promise<void> {
+    const vl = this.vlf.initLog(this.hideKeyboard);
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+      try {
+        if (await util.browser.isAndroid()) {
+          console.log("Hiding keyboard on Android.");
+          vl.log("Hiding keyboard on Android.");
+          await browser.hideKeyboard(strategy, key, keyCode);
+        } else if (await util.browser.isIos()) {
+          console.log("Hiding keyboard on iOS.");
+          vl.log("Hiding keyboard on iOS.");
+          await browser.execute("mobile: hideKeyboard", { strategy });
+        } else {
+          console.warn("Unsupported platform: Unable to hide the keyboard.");
+          return;
+        }
+        console.log("Keyboard hidden successfully.");
+        return; // Exit if the keyboard is successfully hidden
+      } catch (error) {
+        console.warn("Failed to hide the keyboard. Retrying...", error);
+        // Wait briefly before retrying
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+    console.error(`Failed to hide the keyboard within the timeout of ${timeout}ms.`);
+  }
+
+  /**
+   * @function hideKeyboard
+   * @memberof mobile.device
+   * @description Checks if the keyboard is visible or not on the mobile device.
+   * @returns {Promise<boolean>}
+   */
+  async isKeyboardVisible(): Promise<boolean> {
+    const vl = this.vlf.initLog(this.isKeyboardVisible);
+
+    let isKeyboardVisible: boolean = false;
+    try {
+      if (await util.browser.isAndroid()) {
+        vl.log("check if the screen height is reduced due to the keyboard");
+        // For Android, check if the screen height is reduced due to the keyboard
+        const windowRect = await browser.getWindowRect();
+        const screenSize = await browser.getWindowSize();
+        // If the visible height is less, keyboard is visible
+        vl.log("if visible height is less, keyboard is visible");
+        isKeyboardVisible = windowRect.height < screenSize.height;
+        return isKeyboardVisible;
+      } else if (await util.browser.isIos()) {
+        // For iOS, check if the keyboard is displayed via Appium's mobile API
+        const isKeyboardShown = await browser.execute("mobile: isKeyboardShown");
+        isKeyboardVisible = isKeyboardShown === true; // Returns true if the keyboard is visible
+        return isKeyboardVisible;
+      } else {
+        console.warn("Unsupported platform: Unable to detect keyboard visibility.");
+        return false;
+      }
+    } catch (error) {
+      this.ErrorHandler.logException(error, `Error: Failed to get the is keyboard visible`, true);
+      console.error("Failed to get the is keyboard visible", error);
+    }
+    return isKeyboardVisible;
   }
 }
 export default new Device();

--- a/src/reuse/modules/mobile/element.ts
+++ b/src/reuse/modules/mobile/element.ts
@@ -153,8 +153,8 @@ export class ElementModule {
    * @example await mobile.element.waitTotoBeEnabled("#button12");
    * @example await mobile.element.waitTotoBeEnabled("p:first-child");
    */
-  async waitTotoBeEnabled(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
-    const vl = this.vlf.initLog(this.waitTotoBeEnabled);
+  async waitToBeEnabled(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
+    const vl = this.vlf.initLog(this.waitToBeEnabled);
     try {
       vl.log(`wdio.waitTotoBeEnabled invocation for selector ${selector}`);
       await $(selector).toBeEnabled({

--- a/src/reuse/modules/mobile/element.ts
+++ b/src/reuse/modules/mobile/element.ts
@@ -1,6 +1,7 @@
 import { Element } from "../../../../@types/wdio";
 import { VerboseLoggerFactory } from "../../helper/verboseLogger";
 import ErrorHandler from "../../helper/errorHandler";
+import { resolveMobileSelectorOrElement } from "../../helper/elementResolving";
 
 /**
  * @class element
@@ -58,13 +59,19 @@ export class ElementModule {
    * @example await mobile.element.waitToBePresent("#button12");
    * @example await mobile.element.waitToBePresent("p:first-child");
    */
-  async waitToBePresent(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+  async waitToBePresent(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBePresent);
     try {
       vl.log(`wdio.waitForExist invocation for selector ${selector}`);
-      await $(selector).waitForExist({ timeout: timeout });
+      await $(selector).waitForExist({
+        timeout: timeout,
+        interval: 100,
+        timeoutMsg: `Timeout '${+timeout / 1000}s' by waiting for element is present.`
+      });
+      return true;
     } catch (error) {
       this.ErrorHandler.logException(error);
+      return false;
     }
   }
 
@@ -78,13 +85,19 @@ export class ElementModule {
    * @example await mobile.element.waitToBeVisible("#button12");
    * @example await mobile.element.waitToBeVisible("p:first-child");
    */
-  async waitToBeVisible(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async waitToBeVisible(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBeVisible);
     try {
       vl.log(`wdio.waitForDisplayed invocation for selector ${selector}`);
-      await $(selector).waitForDisplayed({ timeout: timeout });
+      await $(selector).waitForDisplayed({
+        timeout: timeout,
+        interval: 100,
+        timeoutMsg: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
+      });
+      return true;
     } catch (error) {
       this.ErrorHandler.logException(error);
+      return false;
     }
   }
 
@@ -98,13 +111,19 @@ export class ElementModule {
    * @example await mobile.element.waitToBeClickable("#button12");
    * @example await mobile.element.waitToBeClickable("p:first-child");
    */
-  async waitToBeClickable(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async waitToBeClickable(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBeClickable);
     try {
       vl.log(`wdio.waitForClickable invocation for selector ${selector}`);
-      await $(selector).waitForClickable({ timeout: timeout });
+      await $(selector).waitForClickable({
+        timeout: timeout,
+        interval: 100,
+        timeoutMsg: `Timeout '${+timeout / 1000}s' by waiting for element is clickable.`
+      });
+      return true;
     } catch (error) {
       this.ErrorHandler.logException(error);
+      return false;
     }
   }
 
@@ -112,14 +131,42 @@ export class ElementModule {
    * @function isSelected
    * @memberof mobile.element
    * @description Returns a boolean if the element (e.g. checkbox) is selected.
-   * @param {Object} elem - The element.
+   * @param {Element | string} elementOrSelector - The element.
    * @returns {boolean}
    * @example const elem = await mobile.element.getById("elem01");
    * const isSelected = await mobile.element.isSelected(elem);
    */
-  async isSelected(elem: Element): Promise<boolean> {
+  async isSelected(elementOrSelector: Element | string): Promise<boolean> {
     const vl = this.vlf.initLog(this.isSelected);
-    return elem.isSelected();
+
+    const element = await resolveMobileSelectorOrElement(elementOrSelector);
+    return await element.isSelected();
+  }
+
+  /**
+   * @function waitTotoBeEnabled
+   * @memberof mobile.element
+   * @description Waits until the element with the given selector is present.
+   * @param {Object} selector - The CSS selector describing the element.
+   * @param {Number} [timeout=30000] - The timeout to wait (ms).
+   * @example await mobile.element.waitTotoBeEnabled(".input01");
+   * @example await mobile.element.waitTotoBeEnabled("#button12");
+   * @example await mobile.element.waitTotoBeEnabled("p:first-child");
+   */
+  async waitTotoBeEnabled(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
+    const vl = this.vlf.initLog(this.waitTotoBeEnabled);
+    try {
+      vl.log(`wdio.waitTotoBeEnabled invocation for selector ${selector}`);
+      await $(selector).toBeEnabled({
+        timeout: timeout,
+        interval: 100,
+        timeoutMsg: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+      });
+      return true;
+    } catch (error) {
+      this.ErrorHandler.logException(error);
+      return false;
+    }
   }
 }
 export default new ElementModule();

--- a/src/reuse/modules/mobile/element.ts
+++ b/src/reuse/modules/mobile/element.ts
@@ -38,7 +38,7 @@ export class ElementModule {
    * @function isPresent
    * @memberof mobile.element
    * @description Returns a boolean if the element is present at the DOM or not. It might be hidden.
-   * @param {Object} elem - The element.
+   * @param {Element} element - The element.
    * @returns {Boolean} Returns true or false.
    * @example
    * await mobile.element.isPresent(elem);

--- a/src/reuse/modules/mobile/element.ts
+++ b/src/reuse/modules/mobile/element.ts
@@ -15,10 +15,10 @@ export class ElementModule {
    * @function isVisible
    * @memberof mobile.element
    * @description Returns a boolean if the mobile element is visible to the user.
-   * @param {Object} element - The Mobile Ui element.
-   * @param {Boolean} [strict=true] - If strict mode is enabled it will only return "true" if the element is visible on the mobile view and within the viewport.
+   * @param {Element} element - The Mobile Ui element.
+   * @param {boolean} [strict=true] - If strict mode is enabled it will only return "true" if the element is visible on the mobile view and within the viewport.
    * If "false", it will be sufficient if the element is visible on the view but not inside the current viewport.
-   * @returns {Boolean} Returns true or false.
+   * @returns {boolean} Returns true or false.
    * @example
    * await mobile.element.isVisible(elem);
    */
@@ -40,7 +40,7 @@ export class ElementModule {
    * @memberof mobile.element
    * @description Returns a boolean if the element is present at the DOM or not. It might be hidden.
    * @param {Element} element - The element.
-   * @returns {Boolean} Returns true or false.
+   * @returns {boolean} Returns true or false.
    * @example
    * await mobile.element.isPresent(elem);
    */
@@ -54,10 +54,12 @@ export class ElementModule {
    * @memberof mobile.element
    * @description Waits until the element with the given selector is present.
    * @param {Object} selector - The CSS selector describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example await mobile.element.waitToBePresent(".input01");
-   * @example await mobile.element.waitToBePresent("#button12");
-   * @example await mobile.element.waitToBePresent("p:first-child");
+   * @param {number} [timeout = 30000] - The timeout to wait (ms).
+   * @returns {boolean} Returns true or false.
+   * @example
+   * await mobile.element.waitToBePresent(".input01");
+   * await mobile.element.waitToBePresent("#button12");
+   * await mobile.element.waitToBePresent("p:first-child");
    */
   async waitToBePresent(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBePresent);
@@ -80,10 +82,12 @@ export class ElementModule {
    * @memberof mobile.element
    * @description Waits until the element with the given selector is visible.
    * @param {Object} selector - The CSS selector describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example await mobile.element.waitToBeVisible(".input01");
-   * @example await mobile.element.waitToBeVisible("#button12");
-   * @example await mobile.element.waitToBeVisible("p:first-child");
+   * @param {number} [timeout=30000] - The timeout to wait (ms).
+   * @returns {boolean} Returns true or false.
+   * @example
+   * await mobile.element.waitToBeVisible(".input01");
+   * await mobile.element.waitToBeVisible("#button12");
+   * await mobile.element.waitToBeVisible("p:first-child");
    */
   async waitToBeVisible(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBeVisible);
@@ -106,10 +110,12 @@ export class ElementModule {
    * @memberof mobile.element
    * @description Waits until the element with the given selector is clickable.
    * @param {Object} selector - The CSS selector describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example await mobile.element.waitToBeClickable(".input01");
-   * @example await mobile.element.waitToBeClickable("#button12");
-   * @example await mobile.element.waitToBeClickable("p:first-child");
+   * @param {number} [timeout=30000] - The timeout to wait (ms).
+   * @returns {boolean} Returns true or false.
+   * @example
+   * await mobile.element.waitToBeClickable(".input01");
+   * await mobile.element.waitToBeClickable("#button12");
+   * await mobile.element.waitToBeClickable("p:first-child");
    */
   async waitToBeClickable(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBeClickable);
@@ -132,7 +138,7 @@ export class ElementModule {
    * @memberof mobile.element
    * @description Returns a boolean if the element (e.g. checkbox) is selected.
    * @param {Element | string} elementOrSelector - The element.
-   * @returns {boolean}
+   * @returns {boolean} Returns true or false.
    * @example
    * const isSelected = await mobile.element.isSelected(elem);
    */
@@ -148,10 +154,12 @@ export class ElementModule {
    * @memberof mobile.element
    * @description Waits until the element with the given selector is present.
    * @param {Object} selector - The CSS selector describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example await mobile.element.waitToBeEnabled(".input01");
-   * @example await mobile.element.waitToBeEnabled("#button12");
-   * @example await mobile.element.waitToBeEnabled("p:first-child");
+   * @param {number} [timeout=30000] - The timeout to wait (ms).
+   * @returns {boolean} Returns true or false.
+   * @example
+   * await mobile.element.waitToBeEnabled(".input01");
+   * await mobile.element.waitToBeEnabled("#button12");
+   * await mobile.element.waitToBeEnabled("p:first-child");
    */
   async waitToBeEnabled(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBeEnabled);

--- a/src/reuse/modules/mobile/element.ts
+++ b/src/reuse/modules/mobile/element.ts
@@ -19,7 +19,7 @@ export class ElementModule {
    * @param {Boolean} [strict=true] - If strict mode is enabled it will only return "true" if the element is visible on the mobile view and within the viewport.
    * If "false", it will be sufficient if the element is visible on the view but not inside the current viewport.
    * @returns {Boolean} Returns true or false.
-   * @example const elem = await mobile.element.isVisible("button01");
+   * @example
    * await mobile.element.isVisible(elem);
    */
   async isVisible(element: Element, strict: boolean = true): Promise<boolean> {
@@ -133,7 +133,7 @@ export class ElementModule {
    * @description Returns a boolean if the element (e.g. checkbox) is selected.
    * @param {Element | string} elementOrSelector - The element.
    * @returns {boolean}
-   * @example const elem = await mobile.element.getById("elem01");
+   * @example
    * const isSelected = await mobile.element.isSelected(elem);
    */
   async isSelected(elementOrSelector: Element | string): Promise<boolean> {
@@ -144,14 +144,14 @@ export class ElementModule {
   }
 
   /**
-   * @function waitTotoBeEnabled
+   * @function waitToBeEnabled
    * @memberof mobile.element
    * @description Waits until the element with the given selector is present.
    * @param {Object} selector - The CSS selector describing the element.
    * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example await mobile.element.waitTotoBeEnabled(".input01");
-   * @example await mobile.element.waitTotoBeEnabled("#button12");
-   * @example await mobile.element.waitTotoBeEnabled("p:first-child");
+   * @example await mobile.element.waitToBeEnabled(".input01");
+   * @example await mobile.element.waitToBeEnabled("#button12");
+   * @example await mobile.element.waitToBeEnabled("p:first-child");
    */
   async waitToBeEnabled(selector: any, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<boolean> {
     const vl = this.vlf.initLog(this.waitToBeEnabled);

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -20,25 +20,23 @@ export class UserInteraction {
    * const elem = await mobile.userInteraction.tap(elem);
    * const elem = await mobile.userInteraction.tap(elem, 20000);
    */
-  async tap(element: Element, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async tap(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const vl = this.vlf.initLog(this.tap);
 
     try {
-      vl.log("Expecting element to be displayed and enabled");
+      const tapElement = await $(element);
+      vl.log("Expecting element to be enabled & wait to be visible");
       await Promise.all([
-        expect(element).toBeDisplayed({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
-        }),
-        expect(element).toBeEnabled({
+        expect(tapElement).toBeEnabled({
           wait: timeout,
           interval: 100,
           message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        })
+        }),
+        await mobile.element.waitToBeVisible(tapElement, timeout)
       ]);
+
       vl.log("Tapping on the element");
-      await element.click();
+      await tapElement.click();
       vl.log("Given element is successfully taped on the mobile Ui");
     } catch (error) {
       this.ErrorHandler.logException(error, "Error: During tap", true);
@@ -49,16 +47,28 @@ export class UserInteraction {
    * @function check
    * @memberof mobile.userInteraction
    * @description Checks the given checkbox.
-   * @param {Element} element - The element or CSS selector describing the element.
-   * @example await mobile.userInteraction.check(selector);
+   * @param {Element | string} element - The element or CSS selector describing the element.
+   * @param {number} [timeout = 30000] - The timeout to wait(ms)
+   * @example await mobile.userInteraction.check(element);
    */
-  async check(element: Element) {
+  async check(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const vl = this.vlf.initLog(this.check);
 
     try {
-      const isSelected: boolean = await mobile.element.isSelected(element);
+      const checkElement = await $(element);
+      vl.log("Expecting element to be enabled & wait to be visible");
+      await Promise.all([
+        expect(checkElement).toBeEnabled({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+        }),
+        await mobile.element.waitToBeVisible(checkElement, timeout)
+      ]);
+
+      const isSelected: boolean = await mobile.element.isSelected(checkElement);
       if (!isSelected) {
-        await this.tap(element);
+        await this.tap(checkElement);
       } else {
         vl.log("Checkbox already selected.");
       }
@@ -68,34 +78,67 @@ export class UserInteraction {
   }
 
   /**
+   * @function uncheck
+   * @memberOf mobile.userInteraction
+   * @description Unchecks the given checkbox.
+   * @param {Element} element - The element or CSS selector describing the element.
+   * @param {number} [timeout = 30000] - The timeout to wait(ms)
+   * @example await nonUi5.userInteraction.uncheck(elementOrSelector);
+   */
+  async uncheck(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+    const vl = this.vlf.initLog(this.uncheck);
+
+    try {
+      const uncheckElement = await $(element);
+      vl.log("Expecting element to be enabled & wait to be visible");
+      await Promise.all([
+        expect(uncheckElement).toBeEnabled({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+        }),
+        await mobile.element.waitToBeVisible(uncheckElement, timeout)
+      ]);
+
+      const isSelected: boolean = await mobile.element.isSelected(uncheckElement);
+      if (isSelected) {
+        await this.tap(uncheckElement);
+      } else {
+        vl.log("Checkbox already unchecked.");
+      }
+    } catch (error) {
+      this.ErrorHandler.logException(error);
+    }
+  }
+
+  /**
    * @function doubleTap
    * @memberof mobile.userInteraction
    * @description Double Tap's on the mobile element.
    * @param {Element | string} element - The element or CSS selector describing the element (e.g., accessibility ID, XPath, CSS,).
    * @param {number} [timeout = 30000] - The timeout to wait(ms)
+   * @returns {Promise<void>}
    * @example
-   * const elem = await mobile.userInteraction.doubleTap(elem);
-   * const elem = await mobile.userInteraction.doubleTap(elem, 20000);
+   * await mobile.userInteraction.doubleTap(elem);
+   * await mobile.userInteraction.doubleTap(elem, 2000);
    */
-  async doubleTap(element: Element, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async doubleTap(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.doubleTap);
 
     try {
-      vl.log("Expecting element to be displayed and enabled");
+      const tapElement = await $(element);
+      vl.log("Expecting element to be enabled & wait to be visible");
       await Promise.all([
-        expect(element).toBeDisplayed({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
-        }),
-        expect(element).toBeEnabled({
+        expect(tapElement).toBeEnabled({
           wait: timeout,
           interval: 100,
           message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        })
+        }),
+        await mobile.element.waitToBeVisible(tapElement, timeout)
       ]);
+
       vl.log("Double taping on the element");
-      await element.doubleClick();
+      await tapElement.doubleClick();
       vl.log("Given element is successfully double taped on the mobile Ui");
     } catch (error) {
       this.ErrorHandler.logException(error, "Error: During doubleTap", true);
@@ -103,86 +146,112 @@ export class UserInteraction {
   }
 
   /**
-   * @function setText
+   * @function fill
    * @memberof mobile.userInteraction
    * @description Enter a string value into a mobile input box.
    * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
    * @param {string} value - The string value to be entered.
-   * @param {boolean} [clear = true] - Whether to clear the input box before entering the value.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}
    * @example
-   * const elem = await mobile.userInteraction.setText(elem);
-   * const elem = await mobile.userInteraction.setText(elem, 2000, false);
+   * await mobile.userInteraction.fill(element);
+   * await mobile.userInteraction.fill(element, 2000);
    */
-  async setText(element: Element, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000, clear: boolean = true): Promise<void> {
-    const vl = this.vlf.initLog(this.setText);
+  async fill(element: Element | string, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+    const vl = this.vlf.initLog(this.fill);
 
     try {
       const inputElement = await $(element);
-      vl.log("Expecting element to be displayed and enabled");
+      vl.log("Expecting element to be enabled & wait to be visible");
       await Promise.all([
-        expect(inputElement).toBeDisplayed({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
-        }),
         expect(inputElement).toBeEnabled({
           wait: timeout,
           interval: 100,
           message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        })
+        }),
+        await mobile.element.waitToBeVisible(inputElement, timeout)
       ]);
 
-      if (clear) {
-        // Clear the input box if required
-        await inputElement.clearValue();
-        vl.log("clear the existing text on the given element");
-      }
-
       // Set the value
-      vl.log("setText on the element");
+      vl.log("set text on the element");
       await inputElement.setValue(value);
-      vl.log(`Entered value "${value}" into input box with selector "${element}`);
+      vl.log(`Entered value "${value}" into input box by selector "${element}`);
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During setText", true);
+      this.ErrorHandler.logException(error, "Error: During fill", true);
     }
   }
 
   /**
-   * @function clearText
+   * @function clearAndFill
+   * @memberof mobile.userInteraction
+   * @description Enter a string value into a mobile input box.
+   * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
+   * @param {string} value - The string value to be entered.
+   * @param {number} [timeout = 30000] - The timeout to wait (ms).
+   * @returns {Promise<void>}
+   * @example
+   * await mobile.userInteraction.clearAndFill(element);
+   * await mobile.userInteraction.clearAndFill(element, 2000);
+   */
+  async clearAndFill(element: Element | string, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+    const vl = this.vlf.initLog(this.clearAndFill);
+
+    try {
+      const inputElement = await $(element);
+      vl.log("Expecting element to be enabled & wait to be visible");
+      await Promise.all([
+        expect(inputElement).toBeEnabled({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+        }),
+        await mobile.element.waitToBeVisible(inputElement, timeout)
+      ]);
+
+      // Clear the input box.
+      await inputElement.clearValue();
+      vl.log("Clear the existing text on the given element");
+
+      // Set the value
+      vl.log("set value on the input element");
+      await inputElement.setValue(value);
+      vl.log(`Entered value "${value}" into input box by selector "${element}`);
+    } catch (error) {
+      this.ErrorHandler.logException(error, "Error: During clearAndFill", true);
+    }
+  }
+
+  /**
+   * @function clear
    * @memberof mobile.userInteraction
    * @description Clear a string value into a mobile input box.
    * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}
    * @example
-   * const elem = await mobile.userInteraction.clearText(elem);
-   * const elem = await mobile.userInteraction.clearText(elem, 2000);
+   * await mobile.userInteraction.clear(element);
+   * await mobile.userInteraction.clear(element, 2000);
    */
-  async clearText(element: Element, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
-    const vl = this.vlf.initLog(this.clearText);
+  async clear(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+    const vl = this.vlf.initLog(this.clear);
 
     try {
       const inputElement = await $(element);
-      vl.log("Expecting element to be displayed and enabled");
+      vl.log("Expecting element to be enabled & wait to be visible");
       await Promise.all([
-        expect(inputElement).toBeDisplayed({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
-        }),
         expect(inputElement).toBeEnabled({
           wait: timeout,
           interval: 100,
           message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        })
+        }),
+        await mobile.element.waitToBeVisible(inputElement, timeout)
       ]);
 
+      vl.log("Clearing the existing text on the given element");
       await inputElement.clearValue();
-      vl.log("clear the existing text on the given element");
+      vl.log("Cleared the existing text on the given element");
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During clearText", true);
+      this.ErrorHandler.logException(error, "Error: During clear", true);
     }
   }
 }

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -1,6 +1,7 @@
 import { Element } from "../../../../@types/wdio";
 import { VerboseLoggerFactory } from "../../helper/verboseLogger";
 import ErrorHandler from "../../helper/errorHandler";
+import { resolveMobileSelectorOrElement } from "../../helper/elementResolving";
 
 /**
  * @class userInteraction
@@ -14,32 +15,25 @@ export class UserInteraction {
    * @function tap
    * @memberof mobile.userInteraction
    * @description Tap's on the mobile element.
-   * @param {Element | string} element - The element (e.g., accessibility ID, XPath, CSS,) selectors describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait(ms)
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
+   * @param {Number} [timeout = 30000] - The timeout to wait(ms)
    * @example
-   * const elem = await mobile.userInteraction.tap(elem);
-   * const elem = await mobile.userInteraction.tap(elem, 20000);
+   * await mobile.userInteraction.tap(elem);
+   * await mobile.userInteraction.tap(elem, 20000);
    */
-  async tap(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async tap(elementOrSelector: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.tap);
 
     try {
-      const tapElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(tapElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(tapElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
       vl.log("Tapping on the element");
-      await tapElement.click();
+      await element.click();
       vl.log("Given element is successfully taped on the mobile Ui");
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During tap", true);
+      this.ErrorHandler.logException(error, `Error: element still not tapable after ${timeout} ms`, true);
     }
   }
 
@@ -47,33 +41,29 @@ export class UserInteraction {
    * @function check
    * @memberof mobile.userInteraction
    * @description Checks the given checkbox.
-   * @param {Element | string} element - The element or CSS selector describing the element.
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
    * @param {number} [timeout = 30000] - The timeout to wait(ms)
-   * @example await mobile.userInteraction.check(element);
+   * @example
+   * await mobile.userInteraction.check(element);
+   * await mobile.userInteraction.check(element, 20000);
    */
-  async check(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async check(elementOrSelector: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.check);
 
     try {
-      const checkElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(checkElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(checkElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
-      const isSelected: boolean = await mobile.element.isSelected(checkElement);
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      const isSelected: boolean = await mobile.element.isSelected(element);
       if (!isSelected) {
-        await this.tap(checkElement);
+        await this.tap(element);
+        vl.log("Given element is successfully checked on the mobile Ui");
       } else {
         vl.log("Checkbox already selected.");
       }
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During check", true);
+      this.ErrorHandler.logException(error, `Error: element still not able to check after ${timeout} ms`, true);
     }
   }
 
@@ -81,33 +71,29 @@ export class UserInteraction {
    * @function uncheck
    * @memberOf mobile.userInteraction
    * @description Unchecks the given checkbox.
-   * @param {Element} element - The element or CSS selector describing the element.
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
    * @param {number} [timeout = 30000] - The timeout to wait(ms)
-   * @example await nonUi5.userInteraction.uncheck(elementOrSelector);
+   * @example
+   * await mobile.userInteraction.uncheck(elementOrSelector);
+   * await mobile.userInteraction.uncheck(elementOrSelector, 20000);
    */
-  async uncheck(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+  async uncheck(elementOrSelector: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.uncheck);
 
     try {
-      const uncheckElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(uncheckElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(uncheckElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
-      const isSelected: boolean = await mobile.element.isSelected(uncheckElement);
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      const isSelected: boolean = await mobile.element.isSelected(element);
       if (isSelected) {
-        await this.tap(uncheckElement);
+        await this.tap(element);
+        vl.log("Given element is successfully uncheck on the mobile Ui");
       } else {
         vl.log("Checkbox already unchecked.");
       }
     } catch (error) {
-      this.ErrorHandler.logException(error);
+      this.ErrorHandler.logException(error, `Error: element still not able to uncheck after ${timeout} ms`, true);
     }
   }
 
@@ -115,33 +101,26 @@ export class UserInteraction {
    * @function doubleTap
    * @memberof mobile.userInteraction
    * @description Double Tap's on the mobile element.
-   * @param {Element | string} element - The element or CSS selector describing the element (e.g., accessibility ID, XPath, CSS,).
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
    * @param {number} [timeout = 30000] - The timeout to wait(ms)
    * @returns {Promise<void>}
    * @example
    * await mobile.userInteraction.doubleTap(elem);
    * await mobile.userInteraction.doubleTap(elem, 2000);
    */
-  async doubleTap(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+  async doubleTap(elementOrSelector: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.doubleTap);
 
     try {
-      const tapElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(tapElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(tapElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
       vl.log("Double taping on the element");
-      await tapElement.doubleClick();
+      await element.doubleClick();
       vl.log("Given element is successfully double taped on the mobile Ui");
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During doubleTap", true);
+      this.ErrorHandler.logException(error, `Error: element still not able to double tap after ${timeout} ms`, true);
     }
   }
 
@@ -149,7 +128,7 @@ export class UserInteraction {
    * @function fill
    * @memberof mobile.userInteraction
    * @description Enter a string value into a mobile input field.
-   * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
    * @param {string} value - The string value to be entered.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}
@@ -157,27 +136,21 @@ export class UserInteraction {
    * await mobile.userInteraction.fill(element);
    * await mobile.userInteraction.fill(element, 2000);
    */
-  async fill(element: Element | string, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+  async fill(elementOrSelector: Element | string, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.fill);
 
     try {
-      const inputElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(inputElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(inputElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
+
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
 
       // Set the value
       vl.log("set text on the element");
-      await inputElement.setValue(value);
+      await element.setValue(value);
       vl.log(`Entered value "${value}" into input box by selector "${element}`);
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During fill", true);
+      this.ErrorHandler.logException(error, `Error: element still not able to fill the value after ${timeout} ms`, true);
     }
   }
 
@@ -185,7 +158,7 @@ export class UserInteraction {
    * @function clearAndFill
    * @memberof mobile.userInteraction
    * @description Enter a string into the mobile input field; it will clear the box before submission.
-   * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
    * @param {string} value - The string value to be entered.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}
@@ -193,31 +166,25 @@ export class UserInteraction {
    * await mobile.userInteraction.clearAndFill(element);
    * await mobile.userInteraction.clearAndFill(element, 2000);
    */
-  async clearAndFill(element: Element | string, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+  async clearAndFill(elementOrSelector: Element | string, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.clearAndFill);
 
     try {
-      const inputElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(inputElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(inputElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
+
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
 
       // Clear the input box.
-      await inputElement.clearValue();
+      await element.clearValue();
       vl.log("Clear the existing text on the given element");
 
       // Set the value
       vl.log("set value on the input element");
-      await inputElement.setValue(value);
+      await element.setValue(value);
       vl.log(`Entered value "${value}" into input box by selector "${element}`);
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During clearAndFill", true);
+      this.ErrorHandler.logException(error, `Error: element still not able to fill the value after ${timeout} ms`, true);
     }
   }
 
@@ -225,33 +192,27 @@ export class UserInteraction {
    * @function clear
    * @memberof mobile.userInteraction
    * @description Clear a string value into a mobile input field.
-   * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
+   * @param {Element | string} elementOrSelector - The element (e.g., accessibility ID, XPath) selectors describing the element.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}
    * @example
    * await mobile.userInteraction.clear(element);
    * await mobile.userInteraction.clear(element, 2000);
    */
-  async clear(element: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+  async clear(elementOrSelector: Element | string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
     const vl = this.vlf.initLog(this.clear);
 
     try {
-      const inputElement = await $(element);
-      vl.log("Expecting element to be enabled & wait to be visible");
-      await Promise.all([
-        expect(inputElement).toBeEnabled({
-          wait: timeout,
-          interval: 100,
-          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
-        }),
-        await mobile.element.waitToBeVisible(inputElement, timeout)
-      ]);
+      const element = await resolveMobileSelectorOrElement(elementOrSelector);
+
+      vl.log("Waiting for the element to become enabled and visible within the specified timeout");
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
 
       vl.log("Clearing the existing text on the given element");
-      await inputElement.clearValue();
+      await element.clearValue();
       vl.log("Cleared the existing text on the given element");
     } catch (error) {
-      this.ErrorHandler.logException(error, "Error: During clear", true);
+      this.ErrorHandler.logException(error, `Error: element still not able to clear the value after ${timeout} ms`, true);
     }
   }
 }

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -15,7 +15,7 @@ export class UserInteraction {
    * @memberof mobile.userInteraction
    * @description Tap's on the mobile element.
    * @param {Element | string} element - The element (e.g., accessibility ID, XPath, CSS,) selectors describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait(ms) (default: 30000)
+   * @param {Number} [timeout=30000] - The timeout to wait(ms)
    * @example
    * const elem = await mobile.userInteraction.tap(elem);
    * const elem = await mobile.userInteraction.tap(elem, 20000);

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -108,7 +108,7 @@ export class UserInteraction {
    * @description Enter a string value into a mobile input box.
    * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
    * @param {string} value - The string value to be entered.
-   * @param {boolean} clear - Whether to clear the input box before entering the value (default: true).
+   * @param {boolean} [clear = true] - Whether to clear the input box before entering the value.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}
    * @example

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -14,9 +14,11 @@ export class UserInteraction {
    * @function tap
    * @memberof mobile.userInteraction
    * @description Tap's on the mobile element.
-   * @param {Element | string} element - The element or CSS selector describing the element.
-   * @param {Number} [timeout=30000] - The timeout to wait (ms).
-   * @example const elem = await mobile.userInteraction.tap(elem);
+   * @param {Element | string} element - The element (e.g., accessibility ID, XPath, CSS,) selectors describing the element.
+   * @param {Number} [timeout=30000] - The timeout to wait(ms) (default: 30000)
+   * @example
+   * const elem = await mobile.userInteraction.tap(elem);
+   * const elem = await mobile.userInteraction.tap(elem, 20000);
    */
   async tap(element: Element, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const vl = this.vlf.initLog(this.tap);
@@ -35,11 +37,11 @@ export class UserInteraction {
           message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
         })
       ]);
-      vl.log("Clicking the element");
+      vl.log("Tapping on the element");
       await element.click();
       vl.log("Given element is successfully taped on the mobile Ui");
     } catch (error) {
-      this.ErrorHandler.logException(error);
+      this.ErrorHandler.logException(error, "Error: During tap", true);
     }
   }
 
@@ -61,7 +63,126 @@ export class UserInteraction {
         vl.log("Checkbox already selected.");
       }
     } catch (error) {
-      this.ErrorHandler.logException(error);
+      this.ErrorHandler.logException(error, "Error: During check", true);
+    }
+  }
+
+  /**
+   * @function doubleTap
+   * @memberof mobile.userInteraction
+   * @description Double Tap's on the mobile element.
+   * @param {Element | string} element - The element or CSS selector describing the element (e.g., accessibility ID, XPath, CSS,).
+   * @param {number} [timeout = 30000] - The timeout to wait(ms) (default: 30000).
+   * @example
+   * const elem = await mobile.userInteraction.doubleTap(elem);
+   * const elem = await mobile.userInteraction.doubleTap(elem, 20000);
+   */
+  async doubleTap(element: Element, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
+    const vl = this.vlf.initLog(this.doubleTap);
+
+    try {
+      vl.log("Expecting element to be displayed and enabled");
+      await Promise.all([
+        expect(element).toBeDisplayed({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
+        }),
+        expect(element).toBeEnabled({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+        })
+      ]);
+      vl.log("Double taping on the element");
+      await element.doubleClick();
+      vl.log("Given element is successfully double taped on the mobile Ui");
+    } catch (error) {
+      this.ErrorHandler.logException(error, "Error: During doubleTap", true);
+    }
+  }
+
+  /**
+   * @function setText
+   * @memberof mobile.userInteraction
+   * @description Enter a string value into a mobile input box.
+   * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
+   * @param {string} value - The string value to be entered.
+   * @param {boolean} clear - Whether to clear the input box before entering the value (default: true).
+   * @param {number} [timeout = 30000] - The timeout to wait (ms).
+   * @returns {Promise<void>}
+   * @example
+   * const elem = await mobile.userInteraction.setText(elem);
+   * const elem = await mobile.userInteraction.setText(elem, 2000, false);
+   */
+  async setText(element: Element, value: string, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000, clear: boolean = true): Promise<void> {
+    const vl = this.vlf.initLog(this.setText);
+
+    try {
+      const inputElement = await $(element);
+      vl.log("Expecting element to be displayed and enabled");
+      await Promise.all([
+        expect(inputElement).toBeDisplayed({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
+        }),
+        expect(inputElement).toBeEnabled({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+        })
+      ]);
+
+      if (clear) {
+        // Clear the input box if required
+        await inputElement.clearValue();
+        vl.log("clear the existing text on the given element");
+      }
+
+      // Set the value
+      vl.log("setText on the element");
+      await inputElement.setValue(value);
+      vl.log(`Entered value "${value}" into input box with selector "${element}`);
+    } catch (error) {
+      this.ErrorHandler.logException(error, "Error: During setText", true);
+    }
+  }
+
+  /**
+   * @function clearText
+   * @memberof mobile.userInteraction
+   * @description Clear a string value into a mobile input box.
+   * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
+   * @param {number} [timeout = 30000] - The timeout to wait (ms).
+   * @returns {Promise<void>}
+   * @example
+   * const elem = await mobile.userInteraction.clearText(elem);
+   * const elem = await mobile.userInteraction.clearText(elem, 2000);
+   */
+  async clearText(element: Element, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<void> {
+    const vl = this.vlf.initLog(this.clearText);
+
+    try {
+      const inputElement = await $(element);
+      vl.log("Expecting element to be displayed and enabled");
+      await Promise.all([
+        expect(inputElement).toBeDisplayed({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is displayed.`
+        }),
+        expect(inputElement).toBeEnabled({
+          wait: timeout,
+          interval: 100,
+          message: `Timeout '${+timeout / 1000}s' by waiting for element is enabled.`
+        })
+      ]);
+
+      await inputElement.clearValue();
+      vl.log("clear the existing text on the given element");
+    } catch (error) {
+      this.ErrorHandler.logException(error, "Error: During clearText", true);
     }
   }
 }

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -148,7 +148,7 @@ export class UserInteraction {
   /**
    * @function fill
    * @memberof mobile.userInteraction
-   * @description Enter a string value into a mobile input box.
+   * @description Enter a string value into a mobile input field.
    * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
    * @param {string} value - The string value to be entered.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
@@ -184,7 +184,7 @@ export class UserInteraction {
   /**
    * @function clearAndFill
    * @memberof mobile.userInteraction
-   * @description Enter a string value into a mobile input box.
+   * @description Enter a string into the mobile input field; it will clear the box before submission.
    * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
    * @param {string} value - The string value to be entered.
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
@@ -224,7 +224,7 @@ export class UserInteraction {
   /**
    * @function clear
    * @memberof mobile.userInteraction
-   * @description Clear a string value into a mobile input box.
+   * @description Clear a string value into a mobile input field.
    * @param {Element | string} element - The selector for the input element (e.g., accessibility ID, XPath, CSS,).
    * @param {number} [timeout = 30000] - The timeout to wait (ms).
    * @returns {Promise<void>}

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -28,7 +28,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
       vl.log("Tapping on the element");
       await element.click();
       vl.log("Given element is successfully taped on the mobile Ui");
@@ -54,7 +54,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
       const isSelected: boolean = await mobile.element.isSelected(element);
       if (!isSelected) {
         await this.tap(element);
@@ -84,7 +84,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
       const isSelected: boolean = await mobile.element.isSelected(element);
       if (isSelected) {
         await this.tap(element);
@@ -115,7 +115,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
       vl.log("Double taping on the element");
       await element.doubleClick();
       vl.log("Given element is successfully double taped on the mobile Ui");
@@ -143,7 +143,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
 
       // Set the value
       vl.log("set text on the element");
@@ -173,7 +173,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
 
       // Clear the input box.
       await element.clearValue();
@@ -206,7 +206,7 @@ export class UserInteraction {
       const element = await resolveMobileSelectorOrElement(elementOrSelector);
 
       vl.log("Waiting for the element to become enabled and visible within the specified timeout");
-      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitTotoBeEnabled(element, timeout)]);
+      await Promise.all([mobile.element.waitToBeVisible(element, timeout), mobile.element.waitToBeEnabled(element, timeout)]);
 
       vl.log("Clearing the existing text on the given element");
       await element.clearValue();

--- a/src/reuse/modules/mobile/userInteraction.ts
+++ b/src/reuse/modules/mobile/userInteraction.ts
@@ -72,7 +72,7 @@ export class UserInteraction {
    * @memberof mobile.userInteraction
    * @description Double Tap's on the mobile element.
    * @param {Element | string} element - The element or CSS selector describing the element (e.g., accessibility ID, XPath, CSS,).
-   * @param {number} [timeout = 30000] - The timeout to wait(ms) (default: 30000).
+   * @param {number} [timeout = 30000] - The timeout to wait(ms)
    * @example
    * const elem = await mobile.userInteraction.doubleTap(elem);
    * const elem = await mobile.userInteraction.doubleTap(elem, 20000);


### PR DESCRIPTION
Adding a few more reusable lib to mobile(Android & iOS) platforms, this commit has these below methods:

### mobile.device

```switchToContext```: Switch to the specified( WEBVIEW | NATIVE_APP ) context if available
```getTargetContextIfAvailable```: Returns if the specified target context is available within a given timeout.
```closeApplication```: Close the currently active mobile application
```queryAppState```: Queries the state of the application (e.g., running, background, not installed) on the mobile device(Android or iOS)
```launchApp```: Launches the app for both iOS and Android with a parameterized app identifier
```switchToLandscapeOrientation```: Switches the device orientation to landscape mode
```switchToPortraitOrientation```: Switches the device orientation to portrait mode
```getCurrentOrientation```: Returns the device's current orientation (PORTRAIT or LANDSCAPE)
```hideKeyboard```: Hides the keyboard on both Android and iOS using specific strategies with timeout
```isKeyboardVisible```: Check if the keyboard is visible or not on the mobile device
```isPlatformSupported```: Determine if the current platform is supported, if the current device platform is either Android or iOS


### mobile.userInteraction
```uncheck```: Unchecks the given checkbox
```doubleTap```: Double Tap's on the mobile element
```fill```: Enter a string value into a mobile input box
```clearAndFill```: Enter a string into the mobile input box; it will clear the box before submission
```clear```: Clear a string value into a mobile input field

With these additions, we aim to enhance code maintainability and improve the development workflow across the Qmate mobile codebase.