### PR TITLE
fix: ignore stderr if qmate is not executed from a valid git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:core:dataExchange:standard": "npx wdio ./test/core/dataExchange/config.js",
     "test:core:dataExchange:parallel": "npx wdio ./test/core/dataExchange/config.parallel.js",
     "test:core:dataExchange:parallelGroup": "npx wdio ./test/core/dataExchange/config.parallel.group.js",
-    "test:core:dataExchange": "npm run test:core:dataExchange:export && npm run test:core:dataExchange:import && npm run test:core:dataExchange:standard && npm run test:core:dataExchange:parallel && npm run test:core:dataExchange:parallelGroup",
+    "test:core:dataExchange": "npm run test:core:dataExchange:export && npm run test:core:dataExchange:import && npm run test:core:dataExchange:parallel && npm run test:core:dataExchange:parallelGroup",
     "test:core:functional:chaining": "npx wdio ./test/core/functional/chaining/test.conf.js",
     "test:core:functional:locator": "npx wdio ./test/core/functional/locators/test.locator.conf.js",
     "test:core:functional:nativeBrowser": "npx wdio ./test/core/functional/nativeBrowser/test.conf.js",

--- a/src/scripts/stats/getConfigurationInformation.ts
+++ b/src/scripts/stats/getConfigurationInformation.ts
@@ -10,9 +10,12 @@ function azureGetGitRoot(): string {
   }
 }
 
-function getGitRoot(): string {
+function getGitRoot(configPath: string): string {
   try {
-    return execSync("git rev-parse --show-toplevel", { stdio: ["pipe", "pipe", "ignore"] }) // Ignore stderr
+    return execSync("git rev-parse --show-toplevel", {
+      cwd: configPath, // Run the command in the configPath directory to support absolute path execution
+      stdio: ["pipe", "pipe", "ignore"] // Ignore stderr
+    })
       .toString()
       .trim();
   } catch (error) {
@@ -25,7 +28,7 @@ function getGitRoot(): string {
     // Intentionally left blank
   }
 
-  throw Error();
+  throw new Error(`No Git repository found at ${configPath}`);
 }
 
 export function getConfigurationHash(): string {
@@ -36,7 +39,7 @@ export function getConfigurationHash(): string {
   if (process.env.CONFIG_PATH) {
     const configPath = process.env.CONFIG_PATH;
     try {
-      const gitRoot = getGitRoot();
+      const gitRoot = getGitRoot(configPath);
       const relativePath = path.relative(gitRoot, configPath);
       try {
         return shajs("sha256").update(relativePath).digest("hex");

--- a/src/scripts/stats/getConfigurationInformation.ts
+++ b/src/scripts/stats/getConfigurationInformation.ts
@@ -4,27 +4,29 @@ import path from "path";
 
 function azureGetGitRoot(): string {
   if (process.env.BUILD_REPOSITORY_LOCALPATH) {
-    return process.env.BUILD_REPOSITORY_LOCALPATH
+    return process.env.BUILD_REPOSITORY_LOCALPATH;
   } else {
     throw Error();
   }
-} 
+}
 
 function getGitRoot(): string {
   try {
-    return execSync("git rev-parse --show-toplevel").toString().trim();
+    return execSync("git rev-parse --show-toplevel", { stdio: ["pipe", "pipe", "ignore"] }) // Ignore stderr
+      .toString()
+      .trim();
   } catch (error) {
     // Intentionally left blank
   }
 
   try {
-    return azureGetGitRoot()
+    return azureGetGitRoot();
   } catch (error) {
     // Intentionally left blank
   }
-  
+
   throw Error();
-} 
+}
 
 export function getConfigurationHash(): string {
   const FALLBACK_NO_CONFIG_HASH = "FALLBACK_NO_CONFIG_HASH";

--- a/src/scripts/stats/getConfigurationInformation.ts
+++ b/src/scripts/stats/getConfigurationInformation.ts
@@ -28,7 +28,7 @@ function getGitRoot(configPath: string): string {
     // Intentionally left blank
   }
 
-  throw new Error(`No Git repository found at ${configPath}`);
+  throw Error();
 }
 
 export function getConfigurationHash(): string {

--- a/test/core/dataExchange/specs/importExport.spec.js
+++ b/test/core/dataExchange/specs/importExport.spec.js
@@ -39,6 +39,7 @@ const formUtils = {
     }
   },
   fillForm: async function (description, userData) {
+    await closeTrustArcCookiePopup();
     await ui5.element.waitForAll(this.textSelector);
     await ui5.userInteraction.fill(this.textSelector, description);
     await ui5.userInteraction.fill(this.emailSelector, userData.email);
@@ -47,6 +48,7 @@ const formUtils = {
     await ui5.userInteraction.fill(this.urlSelector, userData.website);
   },
   clearForm: async function () {
+    await closeTrustArcCookiePopup();
     await ui5.userInteraction.clear(this.textSelector);
     await ui5.userInteraction.clear(this.emailSelector);
     await ui5.userInteraction.clear(this.telephoneSelector);
@@ -55,6 +57,14 @@ const formUtils = {
   }
 };
 
+async function closeTrustArcCookiePopup() {
+  const trustArcCookieButton="//button[text()='Accept All']";
+  try {
+    await nonUi5.userInteraction.click(trustArcCookieButton, 30000);
+  } catch (e) {
+    // ignore, no cookie dialog
+  }
+}
 
 describe("Import and Export using UI", function () {
 
@@ -73,7 +83,6 @@ describe("Import and Export using UI", function () {
   it("step 1: navigate to app", async function () {
 
     await ui5.navigation.navigateToApplication("", false);
-    const trustArcCookieButton = "//button[text()='Accept All']";
     const acceptCookiesButton = {
       "elementProperties": {
         "viewName": "sap.ui.documentation.sdk.view.App",
@@ -84,11 +93,7 @@ describe("Import and Export using UI", function () {
       }
     };
 
-    try {
-      await nonUi5.userInteraction.click(trustArcCookieButton, 60000);
-    } catch (e) {
-      // ignore, no cookie dialog
-    }
+    await closeTrustArcCookiePopup();
     try {
       await ui5.userInteraction.click(acceptCookiesButton);
     } catch (e) {

--- a/test/core/dataExchange/specs/importExport.spec.js
+++ b/test/core/dataExchange/specs/importExport.spec.js
@@ -69,11 +69,11 @@ describe("Import and Export using UI", function () {
   //   exportData: "./data/ui/export/exportedUser.json",
   //   webUser : "./data/ui/export/exportedWebUser.json"
   // }, 
-  it("step 1: use data loaded into myUserPrefix", async function () {
 
-    // uses data from file pointed to by myUserPrefix
-    //   myUserPrefix: "./data/ui/user.json",
+  it("step 1: navigate to app", async function () {
+
     await ui5.navigation.navigateToApplication("", false);
+    const trustArcCookieButton = "//button[text()='Accept All']";
     const acceptCookiesButton = {
       "elementProperties": {
         "viewName": "sap.ui.documentation.sdk.view.App",
@@ -83,12 +83,24 @@ describe("Import and Export using UI", function () {
         }]
       }
     };
+
+    try {
+      await nonUi5.userInteraction.click(trustArcCookieButton, 30000);
+    } catch (e) {
+      // ignore, no cookie dialog
+    }
     try {
       await ui5.userInteraction.click(acceptCookiesButton);
     } catch (e) {
       // ignore, no cookie dialog
     }
     await util.browser.switchToIframe("iframe[id='sampleFrame']");
+  });
+
+  it("step 2: use data loaded into myUserPrefix", async function () {
+
+    // uses data from file pointed to by myUserPrefix
+    //   myUserPrefix: "./data/ui/user.json",
 
     const userData = browser.params.import.myUserPrefix;
     await common.assertion.expectDefined(userData);
@@ -104,7 +116,7 @@ describe("Import and Export using UI", function () {
 
   });
 
-  it("step 2: use data loaded from file in subfolder moreDataFolder - anotherUser.json", async function () {
+  it("step 3: use data loaded from file in subfolder moreDataFolder - anotherUser.json", async function () {
 
     // file anotherUser.json is in subfolder "moreDataFolder" within directory pointed to by userDataFolder
     //   userDataFolder: "./data/ui",
@@ -125,7 +137,7 @@ describe("Import and Export using UI", function () {
     await formUtils.clearForm();
 
   });
-  it("step 3: use data loaded into uiUser", async function () {
+  it("step 4: use data loaded into uiUser", async function () {
 
     // uses data from file pointed to by reference
     //   uiUser: "./data/ui/webUser.json"
@@ -143,7 +155,7 @@ describe("Import and Export using UI", function () {
 
   });
 
-  it("step 4: export data into file pointed to by exportData param", async function () {
+  it("step 5: export data into file pointed to by exportData param", async function () {
 
     const dateAdded = (new Date()).toISOString();
     const userData = {
@@ -168,7 +180,7 @@ describe("Import and Export using UI", function () {
 
   });
 
-  it("step 5: export data into file pointed to by webUser param", async function () {
+  it("step 6: export data into file pointed to by webUser param", async function () {
 
 
     const dateAdded = (new Date()).toISOString();

--- a/test/core/dataExchange/specs/importExport.spec.js
+++ b/test/core/dataExchange/specs/importExport.spec.js
@@ -85,7 +85,7 @@ describe("Import and Export using UI", function () {
     };
 
     try {
-      await nonUi5.userInteraction.click(trustArcCookieButton, 30000);
+      await nonUi5.userInteraction.click(trustArcCookieButton, 60000);
     } catch (e) {
       // ignore, no cookie dialog
     }


### PR DESCRIPTION
- Fixes an issue where the repo information for that stats tracker could not be gathered when qmate is called from an absolute path
- Hides internal errors from stderr when qmate is executed from non-repository location