### PR TITLE
feat: add function to compare UI5 versions

### DIFF
--- a/src/reuse/modules/util/browser.ts
+++ b/src/reuse/modules/util/browser.ts
@@ -455,5 +455,33 @@ export class Browser {
     vl.log("Indicates is a iOS session? or Android session");
     return browser.isIOS();
   }
+  
+  /**
+   * @function compareUI5Versions
+   * @memberOf util.browser
+   * @description Compares two UI5 versions. If the second (or current) is greater or equal than the first (or compared against) it returns true.
+   * @param {String} compareAgainstVersion - Version you want to compare the UI5 version against.
+   * @param {String} [compareVersion] The UI5 version you want to compare (if not provided getUI5Version).
+   * @param {Number} [timeout=30000] - The timeout to wait (ms).
+   * @example await util.browser.compareUI5Versions('1.133.0');
+   */
+  async compareUI5Versions(compareAgainstVersion: String, compareVersion: String, timeout: number = browser.config.waitForUI5Timeout || 5000) {
+    const vl = this.vlf.initLog(this.compareUI5Versions);
+    compareVersion = compareVersion || (await this.getUI5Version(timeout)).version;
+    const compareAgaisntArray = compareAgainstVersion.split('-')[0].split('.');
+    const compareArray = compareVersion.split('-')[0].split('.');
+    for (let i = 0; i < compareAgaisntArray.length; i++) {
+      if (parseInt(compareArray[i]) > parseInt(compareAgaisntArray[i])) {
+        // UI5 version is greater version
+        return true;
+      } else if (parseInt(compareArray[i]) < parseInt(compareAgaisntArray[i])) {
+        // UI5 version is lower version
+        return false;
+      }
+    }
+    // UI5 versions are equal
+    return true;
+  }
 }
+
 export default new Browser();

--- a/test/reuse/util/browser/compareUI5Versions.spec.js
+++ b/test/reuse/util/browser/compareUI5Versions.spec.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-console */
+"use strict";
+
+const { expect } = require("chai");
+
+describe("browser - compareUI5Versions", function () {
+
+  let isGreaterOrEqual;
+  before("Preparation", async function () {
+    await browser.navigateTo(browser.config.baseUrl);
+    await util.function.executeOptional(async function () {
+      const selector = {
+        "elementProperties": {
+          "viewName": "sap.ui.documentation.sdk.view.App",
+          "metadata": "sap.m.Button",
+          "text": [{
+            "path": "i18n>COOKIE_SETTINGS_DIALOG_FUNCTIONAL_COOKIES_ACCEPT_ALL"
+          }]
+        }
+      };
+      await ui5.userInteraction.click(selector, 0, 15000);
+    }, []);
+  });
+
+  describe("major version", function () {
+    it("Compare greater than", async function () {
+      isGreaterOrEqual = await util.browser.compareUI5Versions('1.1.1', '2.0.0');
+      expect(isGreaterOrEqual).to.be.true;
+    });
+    it("Compare smaller than", async function () {
+      isGreaterOrEqual = await util.browser.compareUI5Versions('2.0.0', '1.1.1');
+      expect(isGreaterOrEqual).to.be.false;
+    });
+  });
+
+  describe("minor version", function () {
+    it("Compare greater than", async function () {
+      isGreaterOrEqual = await util.browser.compareUI5Versions('1.1.1', '1.2.0');
+      expect(isGreaterOrEqual).to.be.true;
+    });
+    it("Compare smaller than", async function () {
+      isGreaterOrEqual = await util.browser.compareUI5Versions('1.2.0', '1.1.1');
+      expect(isGreaterOrEqual).to.be.false;
+    });
+  });
+
+  describe("lowest version", function () {
+    it("Compare greater than", async function () {
+      isGreaterOrEqual = await util.browser.compareUI5Versions('1.1.1', '1.1.2');
+      expect(isGreaterOrEqual).to.be.true;
+    });
+    it("Compare smaller than", async function () {
+      isGreaterOrEqual = await util.browser.compareUI5Versions('1.1.2', '1.1.1');
+      expect(isGreaterOrEqual).to.be.false;
+    });
+  });
+  
+  it("Compare equal than", async function () {
+    isGreaterOrEqual = await util.browser.compareUI5Versions('1.1.1', '1.1.1');
+    expect(isGreaterOrEqual).to.be.true;
+  });
+  
+  it("compare against current version", async function () {
+    const currentUI5Version = await util.browser.getUI5Version().version;
+    isGreaterOrEqual = await util.browser.compareUI5Versions(currentUI5Version);
+    expect(isGreaterOrEqual).to.be.true;
+  });
+
+});


### PR DESCRIPTION
Sometimes the behavior/controles change with ui5 versions.
To guarantee that we don't break stuff for lower ui5 versions we need to compare them.
Since it is a string that has separators etc. I guess it makes sense to have this logic directly in qmate