### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,8 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 name: Node.js CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   generate-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SAP/wdio-qmate-service/security/code-scanning/6](https://github.com/SAP/wdio-qmate-service/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only performs read operations (e.g., checking out code and installing dependencies), we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
