### PR TITLE
Speed up all usages of Promise.any by wrapping in browser.waituntil

### DIFF
--- a/src/reuse/helper/elementResolving.ts
+++ b/src/reuse/helper/elementResolving.ts
@@ -1,12 +1,12 @@
 import { Element } from "../../../@types/wdio";
 
-export async function resolveCssSelectorOrElement(elementOrSelector: Element | string): Promise<Element> {
+export async function resolveCssSelectorOrElement(elementOrSelector: Element | string, timeout = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000): Promise<Element> {
   if (!elementOrSelector) {
     throw new Error("Please provide an element or a CSS selector as first argument.");
   }
 
   if (typeof elementOrSelector === "string") {
-    return await nonUi5.element.getByCss(elementOrSelector);
+    return await nonUi5.element.getByCss(elementOrSelector, 0, timeout);
   } else {
     return elementOrSelector;
   }

--- a/src/reuse/modules/nonUi5/userInteraction.ts
+++ b/src/reuse/modules/nonUi5/userInteraction.ts
@@ -419,12 +419,12 @@ export class UserInteraction {
    * await nonUi5.userInteraction.scrollToElement(elem, alignment);
    */
 
-  async scrollToElement(elementOrSelector: Element | string, alignment: AlignmentOptions | AlignmentValues = "center") {
+  async scrollToElement(elementOrSelector: Element | string, alignment: AlignmentOptions | AlignmentValues = "center", timeout = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const vl = this.vlf.initLog(this.scrollToElement);
     let options = {};
   
     try {
-      const element = await resolveCssSelectorOrElement(elementOrSelector);
+      const element = await resolveCssSelectorOrElement(elementOrSelector, timeout);
       if (typeof alignment === "string") {
         options = {
           block: alignment,

--- a/src/reuse/modules/ui5/navigationBar.ts
+++ b/src/reuse/modules/ui5/navigationBar.ts
@@ -43,14 +43,29 @@ export class NavigationBar {
     const vl = this.vlf.initLog(this.clickSapLogo);
     async function clickLogo() {
       const selector = "//a[@id='shell-header-logo']";
-      await nonUi5.userInteraction.click(selector, timeout);
+      await nonUi5.userInteraction.click(selector, 0);
     }
     async function clickLogoWebComponent() {
       const selector=">>>span[class='ui5-shellbar-logo']";
-      await nonUi5.userInteraction.click(selector, timeout);
+      await nonUi5.userInteraction.click(selector, 0);
     }
     try {
-      await Promise.any([clickLogo(), clickLogoWebComponent()]);
+      await browser.waitUntil(
+        async () => {
+          try {
+            await Promise.any([clickLogo(), clickLogoWebComponent()]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "SAP Logo not clickable",
+          interval: 10
+        }
+      );
     } catch (error) {
       (error as AggregateError).errors.forEach((err) => {
         this.ErrorHandler.logException(err);
@@ -70,7 +85,22 @@ export class NavigationBar {
 
     try {
       // attempt clicking both old and new user icons
-      await Promise.any([clickUserIconOld(), clickUserIconNew()]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            await Promise.any([clickUserIconOld(), clickUserIconNew()]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "User Icon not clickable",
+          interval: 10
+        }
+      );
     } catch (error) {
       (error as AggregateError).errors.forEach((err) => {
         this.ErrorHandler.logException(err);
@@ -84,13 +114,13 @@ export class NavigationBar {
           "id": "*HeaderButton"
         }
       };
-      await ui5.userInteraction.click(selector, 0, timeout);
+      await ui5.userInteraction.click(selector, 0, 0);
     }
 
     async function clickUserIconNew() {
       // TODO: to remove '>>>' after support for v9 is implemented (v9 supports shadow root without '>>>')
       const selector = ">>>[data-ui5-stable='profile']";
-      await nonUi5.userInteraction.click(selector);
+      await nonUi5.userInteraction.click(selector, 0);
     }
   }
 

--- a/src/reuse/modules/ui5/table.ts
+++ b/src/reuse/modules/ui5/table.ts
@@ -28,7 +28,7 @@ export class Table {
    * };
    * await ui5.table.sortColumnAscending("Amount", glAccountItemsTable);
    */
-  async sortColumnAscending(columnName: string, tableSelector: any) {
+  async sortColumnAscending(columnName: string, tableSelector: any, timeout = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const oldSortButtonSelector = {
       elementProperties: {
         metadata: "sap.m.Button",
@@ -56,7 +56,22 @@ export class Table {
     const sort = await this._getSortIndicatorValue(columnName, tableSelector);
     if (sort !== "Ascending") {
       this._clickColumn(columnName, tableSelector);
-      await Promise.any([ui5.userInteraction.click(oldSortButtonSelector), ui5.userInteraction.click(newSortButtonSelector), ui5.userInteraction.click(newerSortButtonSelector)]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            await Promise.any([ui5.userInteraction.click(oldSortButtonSelector,0,0), ui5.userInteraction.click(newSortButtonSelector,0,0), ui5.userInteraction.click(newerSortButtonSelector,0,0)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Sort button not clickable",
+          interval: 10
+        }
+      );
     }
   }
 
@@ -76,7 +91,7 @@ export class Table {
    * };
    * await ui5.table.sortColumnDescending("Amount", glAccountItemsTable);
    */
-  async sortColumnDescending(columnName: string, tableSelector: any) {
+  async sortColumnDescending(columnName: string, tableSelector: any, timeout = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000){
     const oldSortButtonSelector = {
       elementProperties: {
         metadata: "sap.m.Button",
@@ -104,7 +119,22 @@ export class Table {
     const sort = await this._getSortIndicatorValue(columnName, tableSelector);
     if (sort !== "Descending") {
       this._clickColumn(columnName, tableSelector);
-      await Promise.any([ui5.userInteraction.click(oldSortButtonSelector), ui5.userInteraction.click(newSortButtonSelector), ui5.userInteraction.click(newerSortButtonSelector)]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            await Promise.any([ui5.userInteraction.click(oldSortButtonSelector,0,0), ui5.userInteraction.click(newSortButtonSelector,0,0), ui5.userInteraction.click(newerSortButtonSelector,0,0)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Sort button not clickable",
+          interval: 10
+        }
+      );
     }
   }
 
@@ -204,7 +234,7 @@ export class Table {
     }
   }
 
-  private async _clickColumn(name: string, tableSelector: any) {
+  private async _clickColumn(name: string, tableSelector: any, timeout = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const vl = this.vlf.initLog(this._clickColumn);
     const tableColumnSelector = {
       elementProperties: {
@@ -225,23 +255,68 @@ export class Table {
     };
 
     if (!tableSelector) {
-      await Promise.any([ui5.userInteraction.click(tableColumnSelector), ui5.userInteraction.click(tableGridColumnSelector)]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            await Promise.any([ui5.userInteraction.click(tableColumnSelector,0,0), ui5.userInteraction.click(tableGridColumnSelector,0,0)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Column not clickable",
+          interval: 10
+        }
+      );
     }
     if (typeof tableSelector == "number") {
       util.console.warn(`Usage of argument 'index' in function ${arguments.callee.caller.name} is deprecated. Please pass a valid table selector instead.`);
-      await Promise.any([ui5.userInteraction.click(tableColumnSelector, tableSelector), ui5.userInteraction.click(tableGridColumnSelector, tableSelector)]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            await Promise.any([ui5.userInteraction.click(tableColumnSelector, tableSelector, 0), ui5.userInteraction.click(tableGridColumnSelector, tableSelector, 0)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Column not clickable",
+          interval: 10
+        }
+      );
     } else if (typeof tableSelector === "object") {
-      await Promise.any([ui5.userInteraction.click(this._prepareAncestorSelector(tableColumnSelector, tableSelector)), ui5.userInteraction.click(this._prepareAncestorSelector(tableGridColumnSelector, tableSelector))]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            await Promise.any([ui5.userInteraction.click(this._prepareAncestorSelector(tableColumnSelector, tableSelector),0), ui5.userInteraction.click(this._prepareAncestorSelector(tableGridColumnSelector, tableSelector),0)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Column not clickable",
+          interval: 10
+        }
+      );
     }
   }
 
   private async _getSortValudGridTable(selector: any, ancestor?: any) {
-    const sortOrder = await ui5.element.getPropertyValue(selector, "sortOrder", ancestor);
-    const sorted = await ui5.element.getPropertyValue(selector, "sorted", ancestor);
+    const sortOrder = await ui5.element.getPropertyValue(selector, "sortOrder", ancestor,0);
+    const sorted = await ui5.element.getPropertyValue(selector, "sorted", ancestor,0);
     return sorted ? sortOrder : "";
   }
 
-  private async _getSortIndicatorValue(name: string, tableSelector: any) {
+  private async _getSortIndicatorValue(name: string, tableSelector: any, timeout = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || 30000) {
     const vl = this.vlf.initLog(this._getSortIndicatorValue);
     const tableColumnSelector = {
       elementProperties: {
@@ -261,16 +336,63 @@ export class Table {
       }
     };
 
+    let sortIndicator;
     if (!tableSelector) {
-      return Promise.any([ui5.element.getPropertyValue(tableColumnSelector, "sortIndicator"), this._getSortValudGridTable(tableGridColumnSelector)]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            sortIndicator = await Promise.any([ui5.element.getPropertyValue(tableColumnSelector, "sortIndicator",0,0), this._getSortValudGridTable(tableGridColumnSelector)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Sort indicator not found",
+          interval: 10
+        }
+      );
     }
     if (typeof tableSelector == "number") {
       util.console.warn(`The usage of argument 'index' in function ${arguments.callee.caller.name} is deprecated. Please pass a valid table selector instead.`);
-      return Promise.any([ui5.element.getPropertyValue(tableColumnSelector, "sortIndicator", tableSelector), this._getSortValudGridTable(tableGridColumnSelector, tableSelector)]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            sortIndicator = await Promise.any([ui5.element.getPropertyValue(tableColumnSelector, "sortIndicator", tableSelector, 0), this._getSortValudGridTable(tableGridColumnSelector, tableSelector)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Sort indicator not found",
+          interval: 10
+        }
+      );
     } else if (typeof tableSelector === "object") {
       const selector = this._prepareAncestorSelector(tableColumnSelector, tableSelector);
-      return Promise.any([ui5.element.getPropertyValue(this._prepareAncestorSelector(tableColumnSelector, tableSelector), "sortIndicator"), this._getSortValudGridTable(this._prepareAncestorSelector(tableGridColumnSelector, tableSelector))]);
+      await browser.waitUntil(
+        async () => {
+          try{
+            sortIndicator = await Promise.any([ui5.element.getPropertyValue(this._prepareAncestorSelector(tableColumnSelector, tableSelector), "sortIndicator",0,0), this._getSortValudGridTable(this._prepareAncestorSelector(tableGridColumnSelector, tableSelector), undefined)]);
+            return true;
+          } catch (error) {
+            // Ignore error and continue to next promise
+            return false;
+          }
+        },
+        {
+          timeout: timeout,
+          timeoutMsg: "Sort indicator not found",
+          interval: 10
+        }
+      );
     }
+    return sortIndicator;
   }
 
   private _prepareAncestorSelector(selector: any, ancestorSelector: any) {

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -579,8 +579,23 @@ export class UserInteraction {
             text: value
           }
         };
-        await Promise.any([ui5.userInteraction.click(menuItemSelectorNewUI5, 0, timeout), 
-                           ui5.userInteraction.click(menuItemSelectorOldUI5, 0, timeout)]);
+        await browser.waitUntil(
+          async () => {
+            try{
+              await Promise.any([ui5.userInteraction.click(menuItemSelectorNewUI5, 0, 0), 
+                ui5.userInteraction.click(menuItemSelectorOldUI5, 0, 0)]);
+            } catch (error) {
+              // Ignore error and continue to next promise
+              return false;
+            }
+          },
+          {
+            timeout: timeout,
+            timeoutMsg: "Menu Item not clickable after " + timeout / 1000 + "s",
+            interval: 10
+          }
+        );
+        
         
         const tabSwitchedSuccessfully: boolean = await this._verifyTabSwitch(selector);
         if (tabSwitchedSuccessfully === false) {

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -11,9 +11,24 @@ exports.handleCookiesConsent = async function handleCookiesConsent() {
       }
     };
     const newCookiesConsentDialog = "button[id='truste-consent-button']";
-    await Promise.any([
-      ui5.userInteraction.click(oldCookiesConsentDialog, 0, 15000),
-      nonUi5.userInteraction.click(newCookiesConsentDialog, 0, 15000)
-    ]);
+    await browser.waitUntil(
+      async () => {
+        try{
+          await Promise.any([
+            ui5.userInteraction.click(oldCookiesConsentDialog, 0, 0),
+            nonUi5.userInteraction.click(newCookiesConsentDialog, 0, 0)
+          ]);
+          return true;
+        } catch (error) {
+          // Ignore error and continue to next promise
+          return false;
+        }
+      },
+      {
+        timeout: 15000,
+        timeoutMsg: "Cookies consent dialog not found",
+        interval: 10
+      }
+    );
   }, []);
 };


### PR DESCRIPTION
Promise.any will wait for all included promises to finish. This means in all cases where there is only a wait for a single one required it will wait the full timeout.
This is not very efficient.
Instead it should be regularly polled with the individual Promises having a small timeout.

This will result in a shorter wait and also no pending promises like we would have with Promise.race.