### PR TITLE
fix: wild cards did not match across new lines, adding 's-flag'

### DIFF
--- a/src/scripts/locators/qmateLocatorSrc/comparators/Comparator.ts
+++ b/src/scripts/locators/qmateLocatorSrc/comparators/Comparator.ts
@@ -3,7 +3,7 @@ export class Comparator {
   public static compareWithWildCard(sWild: string, value: any, toLowerCase: boolean = false): boolean {
     const strWild = toLowerCase ? Comparator.convertToString(sWild).trim().toLowerCase() : Comparator.convertToString(sWild).trim();
     const strValue = toLowerCase ? Comparator.convertToString(value).trim().toLowerCase() : Comparator.convertToString(value).trim();
-    const regex = new RegExp("^" + strWild.replace(/[-\/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*") + "$");
+    const regex = new RegExp("^" + strWild.replace(/[-\/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*") + "$", "s");
     return regex.test(strValue);
   }
 


### PR DESCRIPTION
"regression" issue: 
wildcards in selector does not match across new lines/line breaks:

actual value in text property: `"Files in process: 1\n\nCAMT_053.js (ID: 8619)"`
selector: 
`
  const messageSelector = {
          "elementProperties": {
              "metadata": "sap.m.Text",
              "text": "Files in process: 1*"
          }
        };`
