### PR TITLE
update time picker selectors

### DIFF
--- a/src/reuse/modules/ui5/date.ts
+++ b/src/reuse/modules/ui5/date.ts
@@ -181,7 +181,6 @@ export class DateModule {
   private async _clickOk() {
     const selector = {
       "elementProperties": {
-        "viewName": "sap.m.sample.DateTimePicker.Group",
         "metadata": "sap.m.Button",
         "text": "OK"
       }


### PR DESCRIPTION
some time picker selectors have a different viewName and don't have a tooltip property, hence adjusting the selector