### PR TITLE
fix: remove clearValue method and apply browser execute

### DIFF
--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -295,12 +295,8 @@ export class UserInteraction {
    */
   async clear(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.clear);
-
     const id = await ui5.element.getId(selector, index, timeout);
-    const isTextArea = UserInteraction.SUPPORTED_TEXTAREA_METADATA.includes(selector.elementProperties.metadata);
-    const elem = await nonUi5.element.getByCss(`[id='${id}'] ${isTextArea ? "textarea" : "input"}`, 0, timeout);
-    await elem.clearValue();
-
+    
     // Remove tokens/tags if displayed. Use isDisplayed() instead of isExisting() because
     // the .sapMTokenizer node can exist in the DOM but be hidden (e.g. when no tokens are present),
     // which would cause the subsequent click() to fail with a "not displayed" timeout.
@@ -311,8 +307,40 @@ export class UserInteraction {
       await common.userInteraction.pressBackspace();
     }
 
-    await elem.click(); // leave focus
+    // Do NOT use webdriverIO clearValue() here! Some of popovers hides after clearValue call instead of stay in focus.
+    // This can lead to the cases when value is cleared but popover closes and discard changes.
+    const isTextArea = UserInteraction.SUPPORTED_TEXTAREA_METADATA.includes(selector.elementProperties.metadata);
+    await browser.execute(function (id: string, isTextArea: boolean) {
+      // @ts-ignore
+      const input = document.getElementById(id).getElementsByTagName(isTextArea ? "textarea" : "input")[0];
+      input.value = "";
+      input.focus();
+    }, id, isTextArea);
   }
+
+  // async clear(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
+  //   const vl = this.vlf.initLog(this.clear);
+  //   const id = await ui5.element.getId(selector, index, timeout);
+    
+  //   // Remove tokens/tags if exists
+  //   const tokenizer: Element = $(`[id='${id}'] .sapMTokenizer`);
+  //   if (await tokenizer.isExisting()) {
+  //     await nonUi5.userInteraction.click(tokenizer);
+  //     await nonUi5.userInteraction.selectAll(tokenizer, timeout);
+  //     await common.userInteraction.pressBackspace();
+  //   }
+    
+  //   const isTextArea = UserInteraction.SUPPORTED_TEXTAREA_METADATA.includes(selector.elementProperties.metadata);
+  //   await browser.execute(function (id: string, isTextArea: boolean) {
+  //     // @ts-ignore
+  //     const input = document.getElementById(id).getElementsByTagName(isTextArea ? "textarea" : "input")[0];
+  //     input.value = "";
+  //     input.focus();
+  //   }, "application-CRPResource-scheduleOrder-component---MainView--OrderTableColumnFrag--ordNoColId-menu-filter", isTextArea);
+  //   // await elem.click(); // leave focus
+  //   // await util.browser.sleep(3_000);
+
+  // }
 
   /**
    * @function clearAndRetry

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -318,30 +318,6 @@ export class UserInteraction {
     }, id, isTextArea);
   }
 
-  // async clear(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
-  //   const vl = this.vlf.initLog(this.clear);
-  //   const id = await ui5.element.getId(selector, index, timeout);
-    
-  //   // Remove tokens/tags if exists
-  //   const tokenizer: Element = $(`[id='${id}'] .sapMTokenizer`);
-  //   if (await tokenizer.isExisting()) {
-  //     await nonUi5.userInteraction.click(tokenizer);
-  //     await nonUi5.userInteraction.selectAll(tokenizer, timeout);
-  //     await common.userInteraction.pressBackspace();
-  //   }
-    
-  //   const isTextArea = UserInteraction.SUPPORTED_TEXTAREA_METADATA.includes(selector.elementProperties.metadata);
-  //   await browser.execute(function (id: string, isTextArea: boolean) {
-  //     // @ts-ignore
-  //     const input = document.getElementById(id).getElementsByTagName(isTextArea ? "textarea" : "input")[0];
-  //     input.value = "";
-  //     input.focus();
-  //   }, "application-CRPResource-scheduleOrder-component---MainView--OrderTableColumnFrag--ordNoColId-menu-filter", isTextArea);
-  //   // await elem.click(); // leave focus
-  //   // await util.browser.sleep(3_000);
-
-  // }
-
   /**
    * @function clearAndRetry
    * @memberOf ui5.userInteraction


### PR DESCRIPTION
Yet another fix on ui5.userInteraction.clear method.
- Replace wdio clearValue() method with browser script
- Switch code parts placement to reduce code by removing elem.click() to leave focuse
- Add descriptive comment on why builtin clearValue should not be used in this method

Issue details: Some of the inputs are placed on focus sensitive elements (like table column filters popovers) that hides right after clearValue() was called. And if that element change it state only when "Enter" is pressed then after popover closes changes are not apply.
<img width="291" height="148" alt="Screenshot 2026-04-08 at 19 46 10" src="https://github.com/user-attachments/assets/09140edb-965c-4464-ac9e-6d12c7c5dbe6" />
