### PR TITLE
fix: click resolves foreground element when multiple dialogs share the same selector

### DIFF
--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -22,6 +22,7 @@ export class UserInteraction {
   private static readonly TEXTAREA_MACROS_METADATA: Ui5ControlMetadata = "sap.fe.macros.field.TextAreaEx";
   private static readonly SUPPORTED_TEXTAREA_METADATA: Array<Ui5ControlMetadata> = [UserInteraction.TEXTAREA_METADATA, UserInteraction.TEXTAREA_MACROS_METADATA];
   private static readonly SELECT_DEPRECATION_MESSAGE: string = "This function is deprecated, please use the generic 'ui5.userInteraction.select' function instead.";
+  private static readonly OVERLAY_CHECK_TIMEOUT = 5000;
 
   // =================================== CLICK ===================================
   /**
@@ -35,22 +36,8 @@ export class UserInteraction {
    */
   async click(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.click);
-    let elem = null;
-    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    const elem = await this._waitForClickable(selector, index, timeout);
     try {
-      await browser.waitUntil(
-        async function () {
-          elem = await ui5.element.getDisplayed(selector, index, timeout);
-          if (!elem) return false;
-          return elem.isClickable();
-        },
-        { timeout, timeoutMsg }
-      );
-    } catch (error: any) {
-      elem = await this._fallbackOnOverlay(error, timeoutMsg, selector, index);
-    }
-    try {
-      // @ts-ignore
       await elem.click();
     } catch (error) {
       // @ts-ignore
@@ -85,22 +72,8 @@ export class UserInteraction {
    */
   async doubleClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.doubleClick);
-    let elem = null;
-    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    const elem = await this._waitForClickable(selector, index, timeout);
     try {
-      await browser.waitUntil(
-        async function () {
-          elem = await ui5.element.getDisplayed(selector, index, timeout);
-          if (!elem) return false;
-          return elem.isClickable();
-        },
-        { timeout, timeoutMsg }
-      );
-    } catch (error: any) {
-      elem = await this._fallbackOnOverlay(error, timeoutMsg, selector, index);
-    }
-    try {
-      // @ts-ignore
       await elem.doubleClick();
     } catch (error) {
       // @ts-ignore
@@ -120,22 +93,8 @@ export class UserInteraction {
    */
   async rightClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.rightClick);
-    let elem = null;
-    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    const elem = await this._waitForClickable(selector, index, timeout);
     try {
-      await browser.waitUntil(
-        async function () {
-          elem = await ui5.element.getDisplayed(selector, index, timeout);
-          if (!elem) return false;
-          return elem.isClickable();
-        },
-        { timeout, timeoutMsg }
-      );
-    } catch (error: any) {
-      elem = await this._fallbackOnOverlay(error, timeoutMsg, selector, index);
-    }
-    try {
-      // @ts-ignore
       await elem.click({ button: "right" });
     } catch (error) {
       // @ts-ignore
@@ -734,19 +693,45 @@ export class UserInteraction {
   }
 
   // =================================== HELPER ===================================
-  private async _fallbackOnOverlay(error: any, timeoutMsg: string, selector: any, index: number): Promise<Element> {
-    if (error?.message !== timeoutMsg) throw error;
-    const isBlockedByOverlay: boolean = await browser.execute(() => !!document.querySelector(".sapUiBLy"));
-    if (!isBlockedByOverlay) throw error;
-    for (let i = index + 1; ; i++) {
-      let candidateElem: Element;
-      try {
-        candidateElem = await ui5.element.getDisplayed(selector, i, 5000);
-      } catch {
-        throw error;
-      }
-      if (await candidateElem.isClickable()) return candidateElem;
+  private async _waitForClickable(selector: any, index: number, timeout: number): Promise<Element> {
+    let elem: Element | null = null;
+    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    const firstPhaseTimeout = Math.min(timeout, UserInteraction.OVERLAY_CHECK_TIMEOUT);
+    const firstPhaseMsg = firstPhaseTimeout < timeout ? "quick" : timeoutMsg;
+
+    const poll = async () => {
+      elem = await ui5.element.getDisplayed(selector, index, timeout);
+      return !!(elem && await elem.isClickable());
+    };
+
+    try {
+      await browser.waitUntil(poll, { timeout: firstPhaseTimeout, timeoutMsg: firstPhaseMsg });
+      return elem!;
+    } catch (e: any) {
+      if (e?.message !== "quick") throw e;
     }
+
+    // Check once, outside the polling loop, whether a UI5 block layer (class "sapUiBLy") is
+    // physically covering the center of this specific element.
+    const isBlocked: boolean = await browser.execute((el: HTMLElement) => {
+      const rect = el.getBoundingClientRect();
+      const topElem = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      return topElem?.classList?.contains("sapUiBLy") ?? false;
+    }, elem as any);
+    if (isBlocked) {
+      for (let i = index + 1; ; i++) {
+        try {
+          const candidate = await ui5.element.getDisplayed(selector, i, 5000);
+          if (await candidate.isClickable()) return candidate;
+        } catch {
+          throw new Error(timeoutMsg);
+        }
+      }
+    }
+
+    // No overlay — continue waiting for the remaining time.
+    await browser.waitUntil(poll, { timeout: timeout - firstPhaseTimeout, timeoutMsg });
+    return elem!;
   }
 
   private async _verifyTabSwitch(selector: any): Promise<boolean> {

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -676,52 +676,31 @@ export class UserInteraction {
   // =================================== HELPER ===================================
   private async _waitForClickableAndPerform(selector: any, index: number, timeout: number, action: (elem: Element) => Promise<void>): Promise<void> {
     let elem: Element | null = null;
-    let elemsWereFound = false;
-    try {
-      await browser.waitUntil(
-        async () => {
-          const result = await this._getClickableElement(selector, index, timeout);
-          elemsWereFound = elemsWereFound || result.elemsWereFound;
-          elem = result.elem;
-          return elem !== null;
-        },
-        {
-          timeout,
-          timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
+    await browser.waitUntil(
+      async () => {
+        await ui5.element.getDisplayed(selector, index, timeout);
+
+        const allElems = await ui5.element.getAllDisplayed(selector, timeout);
+        const clickableElems: Element[] = [];
+        for (const e of allElems) {
+          if (await e.isClickable()) {
+            clickableElems.push(e);
+          }
         }
-      );
-    } catch {
-      const msg = elemsWereFound
-        ? `Element not clickable after ${+timeout / 1000}s`
-        : `No visible elements found with selector: ${JSON.stringify(selector)}`;
-      this.ErrorHandler.logException(new Error(), msg);
-      return;
-    }
+        elem = clickableElems.length > index ? clickableElems[index] : null;
+        return elem !== null;
+      },
+      {
+        timeout,
+        timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
+      }
+    );
     try {
       await action(elem!);
     } catch (error) {
       // @ts-ignore
       this.ErrorHandler.logException(error);
     }
-  }
-
-  private async _getClickableElement(selector: any, index: number, timeout: number): Promise<{ elem: Element | null; elemsWereFound: boolean }> {
-    let elems: Element[];
-    try {
-      elems = await ui5.element.getAllDisplayed(selector, Math.min(timeout, 1000));
-    } catch {
-      return { elem: null, elemsWereFound: false };
-    }
-    if (!elems || elems.length === 0) return { elem: null, elemsWereFound: false };
-
-    const clickableElems: Element[] = [];
-    for (const elem of elems) {
-      if (await elem.isClickable()) {
-        clickableElems.push(elem);
-      }
-    }
-    const elem = clickableElems.length > index ? clickableElems[index] : null;
-    return { elem, elemsWereFound: true };
   }
 
   private async _verifyTabSwitch(selector: any): Promise<boolean> {

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -36,7 +36,7 @@ export class UserInteraction {
    */
   async click(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.click);
-    const elem = await this._waitForClickable(selector, index, timeout);
+    const elem = await this._getClickableElement(selector, index, timeout);
     try {
       await elem.click();
     } catch (error) {
@@ -72,7 +72,7 @@ export class UserInteraction {
    */
   async doubleClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.doubleClick);
-    const elem = await this._waitForClickable(selector, index, timeout);
+    const elem = await this._getClickableElement(selector, index, timeout);
     try {
       await elem.doubleClick();
     } catch (error) {
@@ -93,7 +93,7 @@ export class UserInteraction {
    */
   async rightClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.rightClick);
-    const elem = await this._waitForClickable(selector, index, timeout);
+    const elem = await this._getClickableElement(selector, index, timeout);
     try {
       await elem.click({ button: "right" });
     } catch (error) {
@@ -693,7 +693,7 @@ export class UserInteraction {
   }
 
   // =================================== HELPER ===================================
-  private async _waitForClickable(selector: any, index: number, timeout: number): Promise<Element> {
+  private async _getClickableElement(selector: any, index: number, timeout: number): Promise<Element> {
     let elem: Element | null = null;
     const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
     const firstPhaseTimeout = Math.min(timeout, UserInteraction.OVERLAY_CHECK_TIMEOUT);
@@ -701,24 +701,26 @@ export class UserInteraction {
 
     const poll = async () => {
       elem = await ui5.element.getDisplayed(selector, index, timeout);
-      return !!(elem && await elem.isClickable());
+      return !!(elem && (await elem.isClickable()));
     };
 
     try {
       await browser.waitUntil(poll, { timeout: firstPhaseTimeout, timeoutMsg: firstPhaseMsg });
       return elem!;
     } catch (e: any) {
+      // If the error message is not "quick"
+      // → throw → function exits
+      // If the message is "quick"
+      // → swallow the error
+      // → execution continues after the try/catch
       if (e?.message !== "quick") throw e;
     }
 
+    // Element was found but remained non-clickable throughout the first phase.
     // Check once, outside the polling loop, whether a UI5 block layer (class "sapUiBLy") is
     // physically covering the center of this specific element.
-    const isBlocked: boolean = await browser.execute((el: HTMLElement) => {
-      const rect = el.getBoundingClientRect();
-      const topElem = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
-      return topElem?.classList?.contains("sapUiBLy") ?? false;
-    }, elem as any);
-    if (isBlocked) {
+    if (await isBlockedByUi5Overlay(elem!)) {
+      // exits when getDisplayed throws at index i — no further candidates exist
       for (let i = index + 1; ; i++) {
         try {
           const candidate = await ui5.element.getDisplayed(selector, i, 5000);
@@ -732,6 +734,14 @@ export class UserInteraction {
     // No overlay — continue waiting for the remaining time.
     await browser.waitUntil(poll, { timeout: timeout - firstPhaseTimeout, timeoutMsg });
     return elem!;
+
+    async function isBlockedByUi5Overlay(element: Element): Promise<boolean> {
+      return await browser.execute((domEl: HTMLElement) => {
+        const rect = domEl.getBoundingClientRect();
+        const topElem = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        return topElem?.classList?.contains("sapUiBLy") ?? false;
+      }, element as any);
+    }
   }
 
   private async _verifyTabSwitch(selector: any): Promise<boolean> {

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -680,15 +680,22 @@ export class UserInteraction {
       async () => {
         await ui5.element.getDisplayed(selector, index, timeout);
 
-        const allElems = await ui5.element.getAllDisplayed(selector, timeout);
-        const clickableElems: Element[] = [];
-        for (const e of allElems) {
+        const visibleElements = await ui5.element.getAllDisplayed(selector, timeout);
+        if (visibleElements.length <= index) return false;
+
+        if (await visibleElements[index].isClickable()) {
+          elem = visibleElements[index];
+          return true;
+        }
+
+        for (const e of visibleElements) {
           if (await e.isClickable()) {
-            clickableElems.push(e);
+            elem = e;
+            return true;
           }
         }
-        elem = clickableElems.length > index ? clickableElems[index] : null;
-        return elem !== null;
+
+        return false;
       },
       {
         timeout,

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -695,9 +695,13 @@ export class UserInteraction {
   // =================================== HELPER ===================================
   private async _getClickableElement(selector: any, index: number, timeout: number): Promise<Element> {
     let elem: Element | null = null;
-    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    const timeoutMsg = `Element not clickable after ${timeout / 1000}s`;
+
+    // Phase 1: short wait used to quickly detect overlay situations
     const firstPhaseTimeout = Math.min(timeout, UserInteraction.OVERLAY_CHECK_TIMEOUT);
-    const firstPhaseMsg = firstPhaseTimeout < timeout ? "quick" : timeoutMsg;
+    const isQuickPhase = firstPhaseTimeout < timeout;
+
+    const QUICK_TIMEOUT_MSG = "__QUICK_TIMEOUT__";
 
     const poll = async () => {
       elem = await ui5.element.getDisplayed(selector, index, timeout);
@@ -705,39 +709,57 @@ export class UserInteraction {
     };
 
     try {
-      await browser.waitUntil(poll, { timeout: firstPhaseTimeout, timeoutMsg: firstPhaseMsg });
+      // If the element becomes clickable during the quick phase, return immediately.
+      await browser.waitUntil(poll, {
+        timeout: firstPhaseTimeout,
+        timeoutMsg: isQuickPhase ? QUICK_TIMEOUT_MSG : timeoutMsg
+      });
       return elem!;
     } catch (e: any) {
-      // If the error message is not "quick"
-      // → throw → function exits
-      // If the message is "quick"
-      // → swallow the error
-      // → execution continues after the try/catch
-      if (e?.message !== "quick") throw e;
+      // If the error message is not the "quick" timeout, we fail fast and exit the function.
+      //
+      // If it *is* the "quick" timeout, only the initial short wait expired.
+      // This means the element exists but is not clickable yet, and we
+      // intentionally continue with additional checks instead of throwing.
+      if (!isQuickPhase || e?.message !== QUICK_TIMEOUT_MSG) {
+        throw e;
+      }
     }
 
-    // Element was found but remained non-clickable throughout the first phase.
-    // Check once, outside the polling loop, whether a UI5 block layer (class "sapUiBLy") is
-    // physically covering the center of this specific element.
+    // Reached only when:
+    // - the element exists and is displayed
+    // - it is not clickable yet
+    // - the initial "quick" wait timed out
+    // Now check whether the element is physically blocked by a UI5 block layer.
     if (await isBlockedByUi5Overlay(elem!)) {
+      // Try alternative elements with the same selector.
       // exits when getDisplayed throws at index i — no further candidates exist
       for (let i = index + 1; ; i++) {
         try {
           const candidate = await ui5.element.getDisplayed(selector, i, 5000);
-          if (await candidate.isClickable()) return candidate;
+          if (await candidate.isClickable()) {
+            return candidate;
+          }
         } catch {
           throw new Error(timeoutMsg);
         }
       }
     }
 
-    // No overlay — continue waiting for the remaining time.
-    await browser.waitUntil(poll, { timeout: timeout - firstPhaseTimeout, timeoutMsg });
+    // Element is not blocked — continue waiting for the remaining time.
+    await browser.waitUntil(poll, {
+      timeout: timeout - firstPhaseTimeout,
+      timeoutMsg
+    });
     return elem!;
 
+    /**
+     * Checks whether the given element is physically covered by a UI5 block layer
+     * (sapUiBLy) at its center position.
+     */
     async function isBlockedByUi5Overlay(element: Element): Promise<boolean> {
-      return await browser.execute((domEl: HTMLElement) => {
-        const rect = domEl.getBoundingClientRect();
+      return browser.execute((el: HTMLElement) => {
+        const rect = el.getBoundingClientRect();
         const topElem = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
         return topElem?.classList?.contains("sapUiBLy") ?? false;
       }, element as any);

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -35,7 +35,27 @@ export class UserInteraction {
    */
   async click(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.click);
-    await this._waitForClickableAndPerform(selector, index, timeout, (elem) => elem.click());
+    let elem = null;
+    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    try {
+      await browser.waitUntil(
+        async function () {
+          elem = await ui5.element.getDisplayed(selector, index, timeout);
+          if (!elem) return false;
+          return elem.isClickable();
+        },
+        { timeout, timeoutMsg }
+      );
+    } catch (error: any) {
+      elem = await this._fallbackOnOverlay(error, timeoutMsg, selector, index);
+    }
+    try {
+      // @ts-ignore
+      await elem.click();
+    } catch (error) {
+      // @ts-ignore
+      this.ErrorHandler.logException(error);
+    }
   }
 
   /**
@@ -65,7 +85,27 @@ export class UserInteraction {
    */
   async doubleClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.doubleClick);
-    await this._waitForClickableAndPerform(selector, index, timeout, (elem) => elem.doubleClick());
+    let elem = null;
+    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    try {
+      await browser.waitUntil(
+        async function () {
+          elem = await ui5.element.getDisplayed(selector, index, timeout);
+          if (!elem) return false;
+          return elem.isClickable();
+        },
+        { timeout, timeoutMsg }
+      );
+    } catch (error: any) {
+      elem = await this._fallbackOnOverlay(error, timeoutMsg, selector, index);
+    }
+    try {
+      // @ts-ignore
+      await elem.doubleClick();
+    } catch (error) {
+      // @ts-ignore
+      this.ErrorHandler.logException(error);
+    }
   }
 
   /**
@@ -80,7 +120,27 @@ export class UserInteraction {
    */
   async rightClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.rightClick);
-    await this._waitForClickableAndPerform(selector, index, timeout, (elem) => elem.click({ button: "right" }));
+    let elem = null;
+    const timeoutMsg = `Element not clickable after ${+timeout / 1000}s`;
+    try {
+      await browser.waitUntil(
+        async function () {
+          elem = await ui5.element.getDisplayed(selector, index, timeout);
+          if (!elem) return false;
+          return elem.isClickable();
+        },
+        { timeout, timeoutMsg }
+      );
+    } catch (error: any) {
+      elem = await this._fallbackOnOverlay(error, timeoutMsg, selector, index);
+    }
+    try {
+      // @ts-ignore
+      await elem.click({ button: "right" });
+    } catch (error) {
+      // @ts-ignore
+      this.ErrorHandler.logException(error);
+    }
   }
 
   /**
@@ -674,51 +734,18 @@ export class UserInteraction {
   }
 
   // =================================== HELPER ===================================
-  private async _waitForClickableAndPerform(selector: any, index: number, timeout: number, action: (elem: Element) => Promise<void>): Promise<void> {
-    let elem: Element | null = null;
-
-    await browser.waitUntil(
-      async () => {
-        const primaryElem = await ui5.element.getDisplayed(selector, index, timeout);
-        if (await primaryElem.isClickable()) {
-          elem = primaryElem;
-          return true;
-        }
-
-        const blockedByUI5Overlay: boolean = await browser.execute((el: HTMLElement) => {
-          const rect = el.getBoundingClientRect();
-          const topElem = document.elementFromPoint(
-            rect.left + rect.width / 2,
-            rect.top + rect.height / 2
-          );
-          return topElem?.classList?.contains("sapUiBLy") ?? false;
-        }, primaryElem);
-
-        if (blockedByUI5Overlay) {
-          for (let i = index + 1; ; i++) {
-            let candidateElem: Element;
-            try {
-              candidateElem = await ui5.element.getDisplayed(selector, i, 500);
-            } catch {
-              return false; 
-            }
-            if (await candidateElem.isClickable()) {
-              elem = candidateElem;
-              return true;
-            }
-          }
-        }
-
-        return false;
-      },
-      { timeout, timeoutMsg: `Element not clickable after ${+timeout / 1000}s` }
-    );
-
-    try {
-      await action(elem!);
-    } catch (error) {
-      // @ts-ignore
-      this.ErrorHandler.logException(error);
+  private async _fallbackOnOverlay(error: any, timeoutMsg: string, selector: any, index: number): Promise<Element> {
+    if (error?.message !== timeoutMsg) throw error;
+    const isBlockedByOverlay: boolean = await browser.execute(() => !!document.querySelector(".sapUiBLy"));
+    if (!isBlockedByOverlay) throw error;
+    for (let i = index + 1; ; i++) {
+      let candidateElem: Element;
+      try {
+        candidateElem = await ui5.element.getDisplayed(selector, i, 5000);
+      } catch {
+        throw error;
+      }
+      if (await candidateElem.isClickable()) return candidateElem;
     }
   }
 

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -35,25 +35,7 @@ export class UserInteraction {
    */
   async click(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.click);
-    let elem = null;
-    await browser.waitUntil(
-      async function () {
-        elem = await ui5.element.getDisplayed(selector, index, timeout);
-        if (!elem) return false;
-        return elem.isClickable();
-      },
-      {
-        timeout,
-        timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
-      }
-    );
-    try {
-      // @ts-ignore
-      await elem.click();
-    } catch (error) {
-      // @ts-ignore
-      this.ErrorHandler.logException(error);
-    }
+    await this._waitForClickableAndPerform(selector, index, timeout, (elem) => elem.click());
   }
 
   /**
@@ -83,25 +65,7 @@ export class UserInteraction {
    */
   async doubleClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.doubleClick);
-    let elem = null;
-    await browser.waitUntil(
-      async function () {
-        elem = await ui5.element.getDisplayed(selector, index, timeout);
-        if (!elem) return false;
-        return elem.isClickable();
-      },
-      {
-        timeout,
-        timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
-      }
-    );
-    try {
-      // @ts-ignore
-      await elem.doubleClick();
-    } catch (error) {
-      // @ts-ignore
-      this.ErrorHandler.logException(error);
-    }
+    await this._waitForClickableAndPerform(selector, index, timeout, (elem) => elem.doubleClick());
   }
 
   /**
@@ -116,27 +80,7 @@ export class UserInteraction {
    */
   async rightClick(selector: any, index = 0, timeout: number = parseFloat(process.env.QMATE_CUSTOM_TIMEOUT!) || GLOBAL_DEFAULT_WAIT_TIMEOUT) {
     const vl = this.vlf.initLog(this.rightClick);
-    let elem = null;
-    await browser.waitUntil(
-      async function () {
-        elem = await ui5.element.getDisplayed(selector, index, timeout);
-        if (!elem) return false;
-        return elem.isClickable();
-      },
-      {
-        timeout,
-        timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
-      }
-    );
-    try {
-      // @ts-ignore
-      await elem.click({
-        button: "right"
-      });
-    } catch (error) {
-      // @ts-ignore
-      this.ErrorHandler.logException(error);
-    }
+    await this._waitForClickableAndPerform(selector, index, timeout, (elem) => elem.click({ button: "right" }));
   }
 
   /**
@@ -730,6 +674,56 @@ export class UserInteraction {
   }
 
   // =================================== HELPER ===================================
+  private async _waitForClickableAndPerform(selector: any, index: number, timeout: number, action: (elem: Element) => Promise<void>): Promise<void> {
+    let elem: Element | null = null;
+    let elemsWereFound = false;
+    try {
+      await browser.waitUntil(
+        async () => {
+          const result = await this._getClickableElement(selector, index, timeout);
+          elemsWereFound = elemsWereFound || result.elemsWereFound;
+          elem = result.elem;
+          return elem !== null;
+        },
+        {
+          timeout,
+          timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
+        }
+      );
+    } catch {
+      const msg = elemsWereFound
+        ? `Element not clickable after ${+timeout / 1000}s`
+        : `No visible elements found with selector: ${JSON.stringify(selector)}`;
+      this.ErrorHandler.logException(new Error(), msg);
+      return;
+    }
+    try {
+      await action(elem!);
+    } catch (error) {
+      // @ts-ignore
+      this.ErrorHandler.logException(error);
+    }
+  }
+
+  private async _getClickableElement(selector: any, index: number, timeout: number): Promise<{ elem: Element | null; elemsWereFound: boolean }> {
+    let elems: Element[];
+    try {
+      elems = await ui5.element.getAllDisplayed(selector, Math.min(timeout, 1000));
+    } catch {
+      return { elem: null, elemsWereFound: false };
+    }
+    if (!elems || elems.length === 0) return { elem: null, elemsWereFound: false };
+
+    const clickableElems: Element[] = [];
+    for (const elem of elems) {
+      if (await elem.isClickable()) {
+        clickableElems.push(elem);
+      }
+    }
+    const elem = clickableElems.length > index ? clickableElems[index] : null;
+    return { elem, elemsWereFound: true };
+  }
+
   private async _verifyTabSwitch(selector: any): Promise<boolean> {
     // two classes required to handle old and new UI5 versions
     const indicatorClasses = ["sapUxAPAnchorBarButtonSelected", "sapMITBSelected"];

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -678,16 +678,13 @@ export class UserInteraction {
     let elem: Element | null = null;
     await browser.waitUntil(
       async () => {
-        await ui5.element.getDisplayed(selector, index, timeout);
-
-        const visibleElements = await ui5.element.getAllDisplayed(selector, timeout);
-        if (visibleElements.length <= index) return false;
-
-        if (await visibleElements[index].isClickable()) {
-          elem = visibleElements[index];
+        const primaryElem = await ui5.element.getDisplayed(selector, index, timeout);
+        if (await primaryElem.isClickable()) {
+          elem = primaryElem;
           return true;
         }
 
+        const visibleElements = await ui5.element.getAllDisplayed(selector, timeout);
         for (const e of visibleElements) {
           if (await e.isClickable()) {
             elem = e;

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -676,6 +676,7 @@ export class UserInteraction {
   // =================================== HELPER ===================================
   private async _waitForClickableAndPerform(selector: any, index: number, timeout: number, action: (elem: Element) => Promise<void>): Promise<void> {
     let elem: Element | null = null;
+
     await browser.waitUntil(
       async () => {
         const primaryElem = await ui5.element.getDisplayed(selector, index, timeout);
@@ -684,24 +685,35 @@ export class UserInteraction {
           return true;
         }
 
-        for (let i = index + 1; ; i++) {
-          let candidateElem: Element;
-          try {
-            candidateElem = await ui5.element.getDisplayed(selector, i, 500);
-          } catch {
-            return false;
-          }
-          if (await candidateElem.isClickable()) {
-            elem = candidateElem;
-            return true;
+        const blockedByUI5Overlay: boolean = await browser.execute((el: HTMLElement) => {
+          const rect = el.getBoundingClientRect();
+          const topElem = document.elementFromPoint(
+            rect.left + rect.width / 2,
+            rect.top + rect.height / 2
+          );
+          return topElem?.classList?.contains("sapUiBLy") ?? false;
+        }, primaryElem);
+
+        if (blockedByUI5Overlay) {
+          for (let i = index + 1; ; i++) {
+            let candidateElem: Element;
+            try {
+              candidateElem = await ui5.element.getDisplayed(selector, i, 500);
+            } catch {
+              return false; 
+            }
+            if (await candidateElem.isClickable()) {
+              elem = candidateElem;
+              return true;
+            }
           }
         }
+
+        return false;
       },
-      {
-        timeout,
-        timeoutMsg: `Element not clickable after ${+timeout / 1000}s`
-      }
+      { timeout, timeoutMsg: `Element not clickable after ${+timeout / 1000}s` }
     );
+
     try {
       await action(elem!);
     } catch (error) {

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -678,16 +678,19 @@ export class UserInteraction {
     let elem: Element | null = null;
     await browser.waitUntil(
       async () => {
+        // Get the element at the requested index — identical to original code.
+        // Also preserves error behavior: throws "No visible elements found" when absent,
+        // which outer waitUntil wraps as "waitUntil condition failed".
         const primaryElem = await ui5.element.getDisplayed(selector, index, timeout);
         if (await primaryElem.isClickable()) {
           elem = primaryElem;
           return true;
         }
 
-        const visibleElements = await ui5.element.getAllDisplayed(selector, timeout);
-        for (const e of visibleElements) {
-          if (await e.isClickable()) {
-            elem = e;
+        const visibleElements = await ui5.element.getAllDisplayed(selector, 500);
+        for (let i = index + 1; i < visibleElements.length; i++) {
+          if (await visibleElements[i].isClickable()) {
+            elem = visibleElements[i];
             return true;
           }
         }

--- a/src/reuse/modules/ui5/userInteraction.ts
+++ b/src/reuse/modules/ui5/userInteraction.ts
@@ -678,24 +678,24 @@ export class UserInteraction {
     let elem: Element | null = null;
     await browser.waitUntil(
       async () => {
-        // Get the element at the requested index — identical to original code.
-        // Also preserves error behavior: throws "No visible elements found" when absent,
-        // which outer waitUntil wraps as "waitUntil condition failed".
         const primaryElem = await ui5.element.getDisplayed(selector, index, timeout);
         if (await primaryElem.isClickable()) {
           elem = primaryElem;
           return true;
         }
 
-        const visibleElements = await ui5.element.getAllDisplayed(selector, 500);
-        for (let i = index + 1; i < visibleElements.length; i++) {
-          if (await visibleElements[i].isClickable()) {
-            elem = visibleElements[i];
+        for (let i = index + 1; ; i++) {
+          let candidateElem: Element;
+          try {
+            candidateElem = await ui5.element.getDisplayed(selector, i, 500);
+          } catch {
+            return false;
+          }
+          if (await candidateElem.isClickable()) {
+            elem = candidateElem;
             return true;
           }
         }
-
-        return false;
       },
       {
         timeout,


### PR DESCRIPTION
When two dialogs are open simultaneously (e.g., a background dialog and a foreground modal), 'ui5.userInteraction.click' fails with "Element not clickable after 30s" even though the correct element was perfectly clickable.

Root cause: 'browser.uiControls()' returns all matching UI5 controls across both dialogs. The element at index 0 was always the background dialog's element — which is covered by the foreground modal overlay and therefore not clickable. The 'waitUntil' loop polled the same non-clickable element for the full timeout duration without ever considering the foreground element.