### PR TITLE
Fix/invisible elements jamming

### DIFF
--- a/src/scripts/locators/qmateLocatorSrc/constants/IgnoredMetadataList.ts
+++ b/src/scripts/locators/qmateLocatorSrc/constants/IgnoredMetadataList.ts
@@ -1,5 +1,6 @@
-// List of sap elements metadata's that exists but actually not presented in the UI tree.
-// Elements with this metadata's should be ignored while filtering valid controls
+// These UI5 controls exist in the control registry but sit outside the standard UI5 control tree
+// (e.g. sap.ui.core.HTML renders raw HTML and has no UI5 parent/child relationships). 
+// Including them during DOM traversal breaks parent and child filtering, so they are skipped and their DOM children are inspected directly instead.
 export const IGNORED_METADATA_LIST = [
   "sap.ui.core.HTML"
 ]

--- a/src/scripts/locators/qmateLocatorSrc/constants/IgnoredMetadataList.ts
+++ b/src/scripts/locators/qmateLocatorSrc/constants/IgnoredMetadataList.ts
@@ -1,0 +1,5 @@
+// List of sap elements metadata's that exists but actually not presented in the UI tree.
+// Elements with this metadata's should be ignored while filtering valid controls
+export const IGNORED_METADATA_LIST = [
+  "sap.ui.core.HTML"
+]

--- a/src/scripts/locators/qmateLocatorSrc/utils/UI5ControlHandler.ts
+++ b/src/scripts/locators/qmateLocatorSrc/utils/UI5ControlHandler.ts
@@ -1,3 +1,4 @@
+import { IGNORED_METADATA_LIST } from "../constants/IgnoredMetadataList";
 import { ControlFinder } from "../utils/ControlFinder";
 import { LocatorDebug } from "../utils/LocatorDebug";
 
@@ -10,7 +11,7 @@ export class UI5ControlHandler {
     Array.prototype.forEach.call(nodes, (node) => {
       const nodeId = node.getAttribute("id");
       const control = ControlFinder.getUI5Control(nodeId);
-      if (control) {
+      if (control && !IGNORED_METADATA_LIST.includes(control.getMetadata()?.getName())) {
         aCandidateControls.push(control);
       } else {
         aCandidateControls.push(...UI5ControlHandler.retrieveValidUI5ControlsSubElements(node.children));
@@ -101,7 +102,7 @@ export class UI5ControlHandler {
     while (true) {
       if (!domParent) return control.getParent?.();
       const oParentControl = ControlFinder.getUI5Control(domParent.getAttribute("id"));
-      if (oParentControl) {
+      if (oParentControl && !IGNORED_METADATA_LIST.includes(oParentControl.getMetadata()?.getName())) {
         return oParentControl;
       }
       domParent = domParent.parentElement;


### PR DESCRIPTION
Some special elements can breaks child/parent selector filtering. See [details](https://github.tools.sap/sProcurement/qmate/issues/1123)