### PR TITLE
Fix/ui5 assertion special chars

### DIFF
--- a/src/reuse/modules/ui5/assertion.ts
+++ b/src/reuse/modules/ui5/assertion.ts
@@ -42,8 +42,8 @@ export class Assertion {
     try {
       await browser.waitUntil(
         async () => {
-          ui5PropertyValue = String(await this._getUI5Property(elem, attribute));
-          innerUI5PropertyValue = String(await this._getInnerUI5Property(elem, attribute));
+          ui5PropertyValue = this._normalizeString(await this._getUI5Property(elem, attribute));
+          innerUI5PropertyValue = this._normalizeString(await this._getInnerUI5Property(elem, attribute));
           if (ui5PropertyValue === compareValue) {
             value = ui5PropertyValue;
             return true;
@@ -95,8 +95,8 @@ export class Assertion {
     try {
       await browser.waitUntil(
         async () => {
-          ui5PropertyValue = String(await this._getUI5Property(elem, attribute));
-          innerUI5PropertyValue = String(await this._getInnerUI5Property(elem, attribute));
+          ui5PropertyValue = this._normalizeString(await this._getUI5Property(elem, attribute));
+          innerUI5PropertyValue = this._normalizeString(await this._getInnerUI5Property(elem, attribute));
           if (ui5PropertyValue.includes(compareValue)) {
             value = ui5PropertyValue;
             return true;
@@ -505,6 +505,15 @@ export class Assertion {
     if (!attribute || typeof attribute !== "string") {
       this.ErrorHandler.logException(new Error("Please check your attribute argument."));
     }
+  }
+
+  private _normalizeString(value: any) {
+    const customSpaceCharacters = new RegExp("[\u00A0\u2002\u2003\u2007\u2009\u202F]", "g");
+    const invisibleCharacters = new RegExp("[\u200B\u200C\u200D\uFEFF]", "g");
+
+    return String(value ?? "")
+      .replace(customSpaceCharacters, " ")
+      .replace(invisibleCharacters, "");
   }
 }
 export default new Assertion();

--- a/test/reuse/ui5/assertion/expectAttributeToBe.spec.js
+++ b/test/reuse/ui5/assertion/expectAttributeToBe.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 let selector;
 
-describe.skip("assertion - expectAttributeToBe: title to be 'Laptops' (string)", function () {
+describe("assertion - expectAttributeToBe: title to be 'Laptops' (string)", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -22,7 +22,7 @@ describe.skip("assertion - expectAttributeToBe: title to be 'Laptops' (string)",
   });
 });
 
-describe.skip("assertion - expectAttributeToBe wrong/null/undefined", function () {
+describe("assertion - expectAttributeToBe wrong/null/undefined", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -50,7 +50,7 @@ describe.skip("assertion - expectAttributeToBe wrong/null/undefined", function (
   });
 });
 
-describe.skip("assertion - expectAttributeToBe: 'visible' of the listItem to be true (boolean and as string)", function () {
+describe("assertion - expectAttributeToBe: 'visible' of the listItem to be true (boolean and as string)", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -72,7 +72,7 @@ describe.skip("assertion - expectAttributeToBe: 'visible' of the listItem to be 
   });
 });
 
-describe.skip("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem to be 1000 (number and as string)", function () {
+describe("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem to be 1000 (number and as string)", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });

--- a/test/reuse/ui5/assertion/expectAttributeToBe.spec.js
+++ b/test/reuse/ui5/assertion/expectAttributeToBe.spec.js
@@ -1,19 +1,19 @@
 "use strict";
-let selector;
 
 describe("assertion - expectAttributeToBe: title to be 'Laptops' (string)", function () {
+  const selector = {
+    elementProperties: {
+      viewName: "sap.ui.demo.cart.view.Home",
+      metadata: "sap.m.StandardListItem",
+      bindingContextPath: "/ProductCategories*'LT')"
+    }
+  };
+
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
 
   it("Execution", async function () {
-    selector = {
-      elementProperties: {
-        viewName: "sap.ui.demo.cart.view.Home",
-        metadata: "sap.m.StandardListItem",
-        bindingContextPath: "/ProductCategories*'LT')"
-      }
-    };
   });
 
   it("Verification", async function () {
@@ -23,18 +23,19 @@ describe("assertion - expectAttributeToBe: title to be 'Laptops' (string)", func
 });
 
 describe("assertion - expectAttributeToBe wrong/null/undefined", function () {
+  const selector = {
+    elementProperties: {
+      viewName: "sap.ui.demo.cart.view.Home",
+      metadata: "sap.m.StandardListItem",
+      bindingContextPath: "/ProductCategories*'LT')"
+    }
+  };
+
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
 
   it("Execution", async function () {
-    selector = {
-      elementProperties: {
-        viewName: "sap.ui.demo.cart.view.Home",
-        metadata: "sap.m.StandardListItem",
-        bindingContextPath: "/ProductCategories*'LT')"
-      }
-    };
   });
 
   it("Verification", async function () {
@@ -51,18 +52,19 @@ describe("assertion - expectAttributeToBe wrong/null/undefined", function () {
 });
 
 describe("assertion - expectAttributeToBe: 'visible' of the listItem to be true (boolean and as string)", function () {
+  const selector = {
+    elementProperties: {
+      viewName: "sap.ui.demo.cart.view.Home",
+      metadata: "sap.m.StandardListItem",
+      bindingContextPath: "/ProductCategories*'LT')"
+    }
+  };
+
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
 
   it("Execution", async function () {
-    selector = {
-      elementProperties: {
-        viewName: "sap.ui.demo.cart.view.Home",
-        metadata: "sap.m.StandardListItem",
-        bindingContextPath: "/ProductCategories*'LT')"
-      }
-    };
   });
 
   it("Verification", async function () {
@@ -73,18 +75,19 @@ describe("assertion - expectAttributeToBe: 'visible' of the listItem to be true 
 });
 
 describe("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem to be 1000 (number and as string)", function () {
+  const selector = {
+    elementProperties: {
+      viewName: "sap.ui.demo.cart.view.Home",
+      metadata: "sap.m.StandardListItem",
+      bindingContextPath: "/ProductCategories*'LT')"
+    }
+  };
+
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
 
   it("Execution", async function () {
-    selector = {
-      elementProperties: {
-        viewName: "sap.ui.demo.cart.view.Home",
-        metadata: "sap.m.StandardListItem",
-        bindingContextPath: "/ProductCategories*'LT')"
-      }
-    };
   });
   it("Verification", async function () {
     await ui5.assertion.expectAttributeToBe(selector, "busyIndicatorDelay", 1000);
@@ -96,7 +99,7 @@ describe("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem 
 describe("assertion - expectAttributeToBe: 'text' is a text with special spaces characters", function () {
   const specialSpacesString = "-\u00A0-\u2002-\u2003-\u2007-\u2009-\u202F-";
   const normalizedString = "- - - - - - -";
-  selector = {
+  const selector = {
     elementProperties: {
       metadata: "sap.m.Title",
       id: "container-cart---homeView--page-title"
@@ -117,7 +120,7 @@ describe("assertion - expectAttributeToBe: 'text' is a text with special spaces 
 describe("assertion - expectAttributeToBe: 'text' is a text with invisible characters", function () {
   const invisibleCharacters = "-\u200B-\u200C-\u200D-\uFEFF-";
   const normalizedString = "-----";
-  selector = {
+  const selector = {
     elementProperties: {
       metadata: "sap.m.Title",
       id: "container-cart---homeView--page-title"

--- a/test/reuse/ui5/assertion/expectAttributeToBe.spec.js
+++ b/test/reuse/ui5/assertion/expectAttributeToBe.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 let selector;
 
-describe("assertion - expectAttributeToBe: title to be 'Laptops' (string)", function () {
+describe.skip("assertion - expectAttributeToBe: title to be 'Laptops' (string)", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -22,7 +22,7 @@ describe("assertion - expectAttributeToBe: title to be 'Laptops' (string)", func
   });
 });
 
-describe("assertion - expectAttributeToBe wrong/null/undefined", function () {
+describe.skip("assertion - expectAttributeToBe wrong/null/undefined", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -50,7 +50,7 @@ describe("assertion - expectAttributeToBe wrong/null/undefined", function () {
   });
 });
 
-describe("assertion - expectAttributeToBe: 'visible' of the listItem to be true (boolean and as string)", function () {
+describe.skip("assertion - expectAttributeToBe: 'visible' of the listItem to be true (boolean and as string)", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -72,7 +72,7 @@ describe("assertion - expectAttributeToBe: 'visible' of the listItem to be true 
   });
 });
 
-describe("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem to be 1000 (number and as string)", function () {
+describe.skip("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem to be 1000 (number and as string)", function () {
   it("Preparation", async function () {
     await browser.url("#/categories");
   });
@@ -90,6 +90,48 @@ describe("assertion - expectAttributeToBe: 'busyIndicatorDelay' of the listItem 
     await ui5.assertion.expectAttributeToBe(selector, "busyIndicatorDelay", 1000);
     await ui5.assertion.expectAttributeToBe(selector, "busyIndicatorDelay", "1000");
     await ui5.assertion.expectAttributeToBe(selector, "busyIndicatorDelay", 1000, 0, 30000, 10000); // Test 'loadPropertyTimeout' parameter
+  });
+});
+
+describe("assertion - expectAttributeToBe: 'text' is a text with special spaces characters", function () {
+  const specialSpacesString = "-\u00A0-\u2002-\u2003-\u2007-\u2009-\u202F-";
+  const normalizedString = "- - - - - - -";
+  selector = {
+    elementProperties: {
+      metadata: "sap.m.Title",
+      id: "container-cart---homeView--page-title"
+    }
+  };
+  
+  it("Preparation", async function () {
+    await browser.url("#/categories");
+    await browser.uiControls(selector);
+    await browser.execute(`sap.ui.getCore().byId("${selector.elementProperties.id}").setText("${specialSpacesString}")`);
+  });
+
+  it("Execution && Verification", async function () {
+    await ui5.assertion.expectAttributeToBe(selector, "text", normalizedString);
+  });
+});
+
+describe("assertion - expectAttributeToBe: 'text' is a text with invisible characters", function () {
+  const invisibleCharacters = "-\u200B-\u200C-\u200D-\uFEFF-";
+  const normalizedString = "-----";
+  selector = {
+    elementProperties: {
+      metadata: "sap.m.Title",
+      id: "container-cart---homeView--page-title"
+    }
+  };
+  
+  it("Preparation", async function () {
+    await browser.url("#/categories");
+    await browser.uiControls(selector);
+    await browser.execute(`sap.ui.getCore().byId("${selector.elementProperties.id}").setText("${invisibleCharacters}")`);
+  });
+
+  it("Execution && Verification", async function () {
+    await ui5.assertion.expectAttributeToBe(selector, "text", normalizedString);
   });
 });
 

--- a/test/reuse/ui5/assertion/expectAttributeToContain.spec.js
+++ b/test/reuse/ui5/assertion/expectAttributeToContain.spec.js
@@ -73,3 +73,45 @@ describe("assertion - expectAttributeToContain with wrong compareValue (unhappy 
     await expect(ui5.assertion.expectAttributeToContain(selector, "text", 123)).rejects.toThrow("Welcome to the Shopping Cart");
   });
 });
+
+describe("assertion - expectAttributeToContain text with special spaces characters", function () {
+  const specialSpacesString = "-\u00A0-\u2002-\u2003-\u2007-\u2009-\u202F-";
+  const normalizedString = "- - - - - - -";
+  const selector = {
+    elementProperties: {
+      metadata: "sap.m.Title",
+      id: "container-cart---homeView--page-title"
+    }
+  };
+
+  it("Preparation", async function () {
+    await browser.url("#/categories");
+    await browser.uiControls(selector);
+    await browser.execute(`sap.ui.getCore().byId("${selector.elementProperties.id}").setText("${specialSpacesString}")`);
+  });
+
+  it("Execution && Verification", async function () {
+    await ui5.assertion.expectAttributeToContain(selector, "text", normalizedString);
+  });
+});
+
+describe("assertion - expectAttributeToContain text with invisible characters", function () {
+  const invisibleCharacters = "-\u200B-\u200C-\u200D-\uFEFF-";
+  const normalizedString = "-----";
+  const selector = {
+    elementProperties: {
+      metadata: "sap.m.Title",
+      id: "container-cart---homeView--page-title"
+    }
+  };
+
+  it("Preparation", async function () {
+    await browser.url("#/categories");
+    await browser.uiControls(selector);
+    await browser.execute(`sap.ui.getCore().byId("${selector.elementProperties.id}").setText("${invisibleCharacters}")`);
+  });
+
+  it("Execution && Verification", async function () {
+    await ui5.assertion.expectAttributeToContain(selector, "text", normalizedString);
+  });
+});


### PR DESCRIPTION
Fix ui5 assertion fails when meet special characters. See [details](https://github.tools.sap/sProcurement/qmate/issues/1149)
