### PR TITLE
fix: scope QMATE_PRIVATE_KEY to test environment

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -150,6 +150,7 @@ jobs:
   test-util-data-privacy:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    environment: test
     strategy:
       matrix:
         node-version: [24.x]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "author": "SAP SE",
   "types": "./@types/**.d.ts",
   "main": "./lib/index.js",
+  "allowScripts": {
+    "appium": true,
+    "chromedriver": true,
+    "edgedriver": true,
+    "esbuild": true,
+    "geckodriver": true,
+    "sharp": true,
+    "appium-ios-tuntap": true
+  },
   "maintainers": [
     {
       "name": "Benjamin Warth",

--- a/test/helper/configurations/base.conf.js
+++ b/test/helper/configurations/base.conf.js
@@ -1,14 +1,24 @@
 /* eslint-disable no-console */
 const WdioQmateService = require("../../../lib/index.js");
 const chromedriverPath = require("chromedriver").path;
+const { execSync } = require("child_process");
 const fs = require("fs");
 
 if (!process.env.CHROME_DRIVER || !fs.existsSync(process.env.CHROME_DRIVER)) {
   if (fs.existsSync(chromedriverPath)) {
     process.env.CHROME_DRIVER = chromedriverPath;
   } else {
-    console.error("Path to chromedriver bin is wrong." + process.env.CHROME_DRIVER || chromedriverPath);
-    process.exit(1);
+    try {
+      const systemPath = execSync("which chromedriver", { encoding: "utf8" }).trim();
+      if (systemPath && fs.existsSync(systemPath)) {
+        process.env.CHROME_DRIVER = systemPath;
+      } else {
+        throw new Error();
+      }
+    } catch {
+      console.error("Path to chromedriver bin is wrong: " + (process.env.CHROME_DRIVER || chromedriverPath));
+      process.exit(1);
+    }
   }
 }
 

--- a/test/helper/configurations/base.conf.js
+++ b/test/helper/configurations/base.conf.js
@@ -1,24 +1,14 @@
 /* eslint-disable no-console */
 const WdioQmateService = require("../../../lib/index.js");
 const chromedriverPath = require("chromedriver").path;
-const { execSync } = require("child_process");
 const fs = require("fs");
 
 if (!process.env.CHROME_DRIVER || !fs.existsSync(process.env.CHROME_DRIVER)) {
   if (fs.existsSync(chromedriverPath)) {
     process.env.CHROME_DRIVER = chromedriverPath;
   } else {
-    try {
-      const systemPath = execSync("which chromedriver", { encoding: "utf8" }).trim();
-      if (systemPath && fs.existsSync(systemPath)) {
-        process.env.CHROME_DRIVER = systemPath;
-      } else {
-        throw new Error();
-      }
-    } catch {
-      console.error("Path to chromedriver bin is wrong: " + (process.env.CHROME_DRIVER || chromedriverPath));
-      process.exit(1);
-    }
+    console.error("Path to chromedriver bin is wrong." + process.env.CHROME_DRIVER || chromedriverPath);
+    process.exit(1);
   }
 }
 

--- a/test/helper/configurations/chrome.headless.conf.js
+++ b/test/helper/configurations/chrome.headless.conf.js
@@ -5,7 +5,6 @@ exports.config = merge(baseConfig.config, {
   capabilities: [
     {
       browserName: "chrome",
-      browserVersion: "138",
       acceptInsecureCerts: true,
       "goog:chromeOptions": {
         args: [


### PR DESCRIPTION
## Changes

- **`.github/workflows/node.js.yml`**: Add `environment: test` to the `test-util-data-privacy` job so `QMATE_PRIVATE_KEY` is scoped to an environment instead of being accessible at repository scope