### PR TITLE
fix: scope QMATE_PRIVATE_KEY to test environment

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -150,6 +150,7 @@ jobs:
   test-util-data-privacy:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    environment: test
     strategy:
       matrix:
         node-version: [24.x]


### PR DESCRIPTION
## Changes

- **`.github/workflows/node.js.yml`**: Add `environment: test` to the `test-util-data-privacy` job so `QMATE_PRIVATE_KEY` is scoped to an environment instead of being accessible at repository scope