### PR TITLE
fix: do not reuse odata service instance if username or password changes in flp.userSettings.getDateFormatFromUserSettings and other user settings functions

### DIFF
--- a/src/reuse/modules/flp/userSettings.ts
+++ b/src/reuse/modules/flp/userSettings.ts
@@ -10,6 +10,8 @@ import { VerboseLoggerFactory } from "../../helper/verboseLogger";
 export class UserSettings {
   private vlf = new VerboseLoggerFactory("util", "userSettings");
   private _srvInstance = null;
+  private _user: string = "";
+  private _password: string = "";
 
   /**
    * @private
@@ -27,12 +29,15 @@ export class UserSettings {
       throw new Error(`${emptyField} is empty, undefined or null. Please provide valid credentials for S4 User Setting Service initialization.`);
     }
 
-    if (!this._srvInstance) {
+    // if username or password changes re-initialize odata service instance
+    if (!this._srvInstance || user !== this._user || password !== this._password) {
       const vl = this.vlf.initLog(await this._initS4UserSettingService);
       const params = browser.config.params;
       if (params?.systemUrl) {
         try {
           this._srvInstance = await service.odata.init(`${params.systemUrl}/sap/opu/odata/UI2/INTEROP`, user, password);
+          this._user = user;
+          this._password = password;
         } catch (error) {
           if (error instanceof Error) {
             throw new Error(`Failed to initialize S4 User Setting Service: ${error.message}.`);

--- a/src/reuse/modules/flp/userSettings.ts
+++ b/src/reuse/modules/flp/userSettings.ts
@@ -29,7 +29,7 @@ export class UserSettings {
       throw new Error(`${emptyField} is empty, undefined or null. Please provide valid credentials for S4 User Setting Service initialization.`);
     }
 
-    // if username or password changes re-initialize odata service instance
+    // If service instance is not initialized, OR username or password changes --> re-initialize odata service instance
     if (!this._srvInstance || user !== this._user || password !== this._password) {
       const vl = this.vlf.initLog(await this._initS4UserSettingService);
       const params = browser.config.params;


### PR DESCRIPTION
If user calls `flp.userSettings.getDateFormatFromUserSettings` with two different sets of usernames and passwords, the second call to this function returns date format for the first user.
This is because we initialize odata service with first user credentials, and retrieve user date settings with the same service instance in all subsequent calls - https://github.com/SAP/wdio-qmate-service/blob/e331e6dc9e75caa4f267126a7c73b8566ed264dd/src/reuse/modules/flp/userSettings.ts#L30

Fixed the code, so that if username or password is changed between calls, the odata service is re-initialized.