### PR TITLE
chore: ungroup security updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,13 +63,6 @@ updates:
       include:
         - "*"
     groups:
-      # Security advisories — keep separate so they're never blocked behind a
-      # large grouped PR review. (Dependabot routes advisory updates here when
-      # they match; otherwise they open as their own PR.)
-      security-updates:
-        applies-to: security-updates
-        patterns:
-          - "*"
       # Production dependencies — small set, group by semver impact so a
       # breaking change is never silently bundled with patches.
       production-minor-and-patch:
@@ -119,10 +112,6 @@ updates:
       include:
         - "*"
     groups:
-      actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
       actions-all:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
Security updates grouped under a catch-all pattern caused Dependabot to bundle unrelated fixes together. When resolving a transitive vulnerability (tmp via @wdio/cli), it silently bumped @wdio/cli across a major version without documenting the change — and the grouped PR made it impossible to accept the valid fixes without also accepting the breaking bump.

Removing the security-updates group so each advisory gets its own PR, making it easy to close problematic resolutions individually.